### PR TITLE
feat(build-node): add target minNodeVersion option to plugin-build-node

### DIFF
--- a/packages/plugin-build-node/src/index.ts
+++ b/packages/plugin-build-node/src/index.ts
@@ -9,6 +9,8 @@ import rollupBabel from 'rollup-plugin-babel';
 import {BuilderOptions, MessageError} from '@pika/types';
 import {rollup} from 'rollup';
 
+const DEFAULT_MIN_NODE_VERSION = '6';
+
 export function manifest(manifest) {
   manifest.main = manifest.main || 'dist-node/index.js';
 }
@@ -40,7 +42,7 @@ export async function build({out, reporter, options}: BuilderOptions): Promise<v
             babelPresetEnv,
             {
               modules: false,
-              targets: {node: options.minNodeVersion || '6'},
+              targets: {node: options.minNodeVersion || DEFAULT_MIN_NODE_VERSION},
               spec: true,
             },
           ],

--- a/packages/plugin-build-node/src/index.ts
+++ b/packages/plugin-build-node/src/index.ts
@@ -24,7 +24,7 @@ export async function beforeJob({out}: BuilderOptions) {
   }
 }
 
-export async function build({out, reporter}: BuilderOptions): Promise<void> {
+export async function build({out, reporter, options}: BuilderOptions): Promise<void> {
   const writeToNode = path.join(out, 'dist-node', 'index.js');
 
   // TODO: KEEP FIXING THIS,
@@ -40,7 +40,7 @@ export async function build({out, reporter}: BuilderOptions): Promise<void> {
             babelPresetEnv,
             {
               modules: false,
-              targets: {node: '6'},
+              targets: {node: options.minNodeVersion || '6'},
               spec: true,
             },
           ],


### PR DESCRIPTION
allows user to specify a version of node to target
closes #2 

expected use
```json
["@pika/plugin-build-node", {"minNodeVersion": 10}],
```