### PR TITLE
Enable to specify tsconfig.json in option

### DIFF
--- a/packages/plugin-ts-standard-pkg/README.md
+++ b/packages/plugin-ts-standard-pkg/README.md
@@ -37,6 +37,15 @@ For more information about @pika/pack & help getting started, [check out the mai
 
 This plugin runs `tsc` internally, so it supports all [tsconfig.json](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html) options defined in your project-level config file (like `compilerOptions` & `exclude`).
 
+You can set your path to `tsconfig.json` in options:
+
+```json
+"@pika/pack": {
+  "pipeline": [
+    ["@pika/plugin-ts-standard-pkg", { "tsconfig": "./tsconfig.build.json" }]
+  ]
+}
+```
 
 ## Result
 

--- a/packages/plugin-ts-standard-pkg/pkg/dist-node/index.js
+++ b/packages/plugin-ts-standard-pkg/pkg/dist-node/index.js
@@ -83,6 +83,20 @@ function readCompilerOptions(configPath) {
   return parsedConfig.options;
 }
 
+function getTsConfigPath(options, cwd) {
+  if (!options || !options.tsconfig) {
+    return path.join(cwd, "tsconfig.json");
+  }
+
+  const tsConfigPath = path.join(cwd, options.tsconfig);
+
+  if (!fs.existsSync(tsConfigPath)) {
+    throw new types.MessageError(`"tsconfig" is set, but not found. Make sure "${path.resolve(tsConfigPath)}" is exists.`);
+  }
+
+  return tsConfigPath;
+}
+
 function beforeBuild(_x) {
   return _beforeBuild.apply(this, arguments);
 }
@@ -168,10 +182,11 @@ function _build() {
   _build = _asyncToGenerator(function* ({
     cwd,
     out,
+    options,
     reporter
   }) {
     const tscBin = path.join(cwd, "node_modules/.bin/tsc");
-    yield execa(tscBin, ["--outDir", path.join(out, "dist-src/"), "-d", "--declarationDir", path.join(out, "dist-types/"), "--declarationMap", "false", "--target", "es2018", "--module", "esnext"], {
+    yield execa(tscBin, ["--outDir", path.join(out, "dist-src/"), "-d", "--declarationDir", path.join(out, "dist-types/"), "--project", getTsConfigPath(options, cwd), "--declarationMap", "false", "--target", "es2018", "--module", "esnext"], {
       cwd
     });
     reporter.created(path.join(out, "dist-src", "index.js"), 'esnext');

--- a/packages/plugin-ts-standard-pkg/pkg/dist-src/index.js
+++ b/packages/plugin-ts-standard-pkg/pkg/dist-src/index.js
@@ -34,6 +34,16 @@ function readCompilerOptions(configPath) {
     }
     return parsedConfig.options;
 }
+function getTsConfigPath(options, cwd) {
+    if (!options || !options.tsconfig) {
+        return path.join(cwd, "tsconfig.json");
+    }
+    const tsConfigPath = path.join(cwd, options.tsconfig);
+    if (!fs.existsSync(tsConfigPath)) {
+        throw new MessageError(`"tsconfig" is set, but not found. Make sure "${path.resolve(tsConfigPath)}" is exists.`);
+    }
+    return tsConfigPath;
+}
 export async function beforeBuild({ cwd, reporter }) {
     const tscBin = path.join(cwd, "node_modules/.bin/tsc");
     if (!fs.existsSync(tscBin)) {
@@ -75,7 +85,7 @@ export function manifest(newManifest) {
     newManifest.types = newManifest.types || 'dist-types/index.d.ts';
     return newManifest;
 }
-export async function build({ cwd, out, reporter }) {
+export async function build({ cwd, out, options, reporter }) {
     const tscBin = path.join(cwd, "node_modules/.bin/tsc");
     await execa(tscBin, [
         "--outDir",
@@ -83,6 +93,8 @@ export async function build({ cwd, out, reporter }) {
         "-d",
         "--declarationDir",
         path.join(out, "dist-types/"),
+        "--project",
+        getTsConfigPath(options, cwd),
         "--declarationMap",
         "false",
         "--target",

--- a/packages/plugin-ts-standard-pkg/pkg/dist-types/index.d.ts
+++ b/packages/plugin-ts-standard-pkg/pkg/dist-types/index.d.ts
@@ -3,4 +3,4 @@ export declare function beforeBuild({ cwd, reporter }: BuilderOptions): Promise<
 export declare function beforeJob({ cwd }: BuilderOptions): Promise<void>;
 export declare function afterJob({ out, reporter }: BuilderOptions): Promise<void>;
 export declare function manifest(newManifest: any): any;
-export declare function build({ cwd, out, reporter }: BuilderOptions): Promise<void>;
+export declare function build({ cwd, out, options, reporter }: BuilderOptions): Promise<void>;

--- a/packages/plugin-ts-standard-pkg/src/index.ts
+++ b/packages/plugin-ts-standard-pkg/src/index.ts
@@ -38,6 +38,18 @@ function formatTscParserErrors(errors: tsc.Diagnostic[]) {
   return parsedConfig.options;
 }
 
+function getTsConfigPath(options: BuilderOptions['options'], cwd: string) {
+  if (!options || !options.tsconfig) {
+    return path.join(cwd, "tsconfig.json");
+  }
+  const tsConfigPath = path.join(cwd, options.tsconfig);
+  if (!fs.existsSync(tsConfigPath)) {
+    throw new MessageError(`"tsconfig" is set, but not found. Make sure "${path.resolve(tsConfigPath)}" is exists.`);
+  }
+
+  return tsConfigPath
+}
+
 
 export async function beforeBuild({cwd, reporter}: BuilderOptions) {
   const tscBin = path.join(cwd, "node_modules/.bin/tsc");
@@ -83,7 +95,7 @@ export function manifest(newManifest) {
   return newManifest;
 }
 
-export async function build({cwd, out, reporter}: BuilderOptions): Promise<void> {
+export async function build({cwd, out, options, reporter}: BuilderOptions): Promise<void> {
   const tscBin = path.join(cwd, "node_modules/.bin/tsc");
     await execa(
       tscBin,
@@ -93,6 +105,8 @@ export async function build({cwd, out, reporter}: BuilderOptions): Promise<void>
         "-d",
         "--declarationDir",
         path.join(out, "dist-types/"),
+        "--project",
+        getTsConfigPath(options, cwd),
         "--declarationMap",
         "false",
         "--target",


### PR DESCRIPTION
Thank you for the great work.

I added an ability to specify tsconfig.json in option.

```json
"@pika/pack": {
  "pipeline": [
    ["@pika/plugin-ts-standard-pkg", { "tsconfig": "./tsconfig.build.json" }]
  ]
}
```

For example, `rollup-plugin-typescript2` has this feature:

https://github.com/ezolenko/rollup-plugin-typescript2#plugin-options

I think it is common use case to use different compiler options between development and build time, so I am very glad if this is merged.

Thanks!