### PR TITLE
Deno: Fix TS file detection, fix paths on Windows

### DIFF
--- a/packages/plugin-build-deno/pkg/dist-node/index.js
+++ b/packages/plugin-build-deno/pkg/dist-node/index.js
@@ -114,12 +114,12 @@ function _build() {
       for (var _iterator = files[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
         const fileAbs = _step.value;
 
-        if (path.extname(fileAbs) !== 'ts' && path.extname(fileAbs) !== 'tsx') {
+        if (path.extname(fileAbs) !== '.ts' && path.extname(fileAbs) !== '.tsx') {
           continue;
         }
 
         const fileRel = path.relative(cwd, fileAbs);
-        const writeToTypeScript = path.resolve(out, fileRel).replace('/src/', '/dist-deno/');
+        const writeToTypeScript = path.resolve(out, fileRel).replace(`${path.sep}src${path.sep}`, `${path.sep}dist-deno${path.sep}`);
         mkdirp.sync(path.dirname(writeToTypeScript));
         fs.copyFileSync(fileAbs, writeToTypeScript);
       }

--- a/packages/plugin-build-deno/pkg/dist-src/index.js
+++ b/packages/plugin-build-deno/pkg/dist-src/index.js
@@ -29,11 +29,11 @@ export async function build({ cwd, out, options }) {
         ignore: (options.exclude || []).map(g => path.join('src', g)),
     });
     for (const fileAbs of files) {
-        if (path.extname(fileAbs) !== 'ts' && path.extname(fileAbs) !== 'tsx') {
+        if (path.extname(fileAbs) !== '.ts' && path.extname(fileAbs) !== '.tsx') {
             continue;
         }
         const fileRel = path.relative(cwd, fileAbs);
-        const writeToTypeScript = path.resolve(out, fileRel).replace('/src/', '/dist-deno/');
+        const writeToTypeScript = path.resolve(out, fileRel).replace(`${path.sep}src${path.sep}`, `${path.sep}dist-deno${path.sep}`);
         mkdirp.sync(path.dirname(writeToTypeScript));
         fs.copyFileSync(fileAbs, writeToTypeScript);
     }

--- a/packages/plugin-build-deno/src/index.ts
+++ b/packages/plugin-build-deno/src/index.ts
@@ -35,11 +35,11 @@ export async function build({cwd, out, options}: BuilderOptions): Promise<void> 
     ignore: (options.exclude || []).map(g => path.join('src', g)),
   });
   for (const fileAbs of files) {
-    if (path.extname(fileAbs) !== 'ts' && path.extname(fileAbs) !== 'tsx') {
+    if (path.extname(fileAbs) !== '.ts' && path.extname(fileAbs) !== '.tsx') {
       continue;
     }
     const fileRel = path.relative(cwd, fileAbs);
-    const writeToTypeScript = path.resolve(out, fileRel).replace('/src/', '/dist-deno/');
+    const writeToTypeScript = path.resolve(out, fileRel).replace(`${path.sep}src${path.sep}`, `${path.sep}dist-deno${path.sep}`);
     mkdirp.sync(path.dirname(writeToTypeScript));
     fs.copyFileSync(fileAbs, writeToTypeScript);
   }


### PR DESCRIPTION
Node's [`path.extname`](https://nodejs.org/api/path.html#path_path_extname_path) includes the dot in the output, but the builder was comparing against a dotless extension.

Also the output path was failing on Windows because of path separator differences. There's probably a better way to make these paths without resorting to adding `${path.sep}` everywhere, but it works for a simple case like this.