### PR TITLE
types: Unbreak TypeScript declarations extraction after tsconfig change

### DIFF
--- a/packages/plugin-build-types/src/index.ts
+++ b/packages/plugin-build-types/src/index.ts
@@ -53,9 +53,9 @@ export async function build({
           "--emitDeclarationOnly",
           "--declarationMap",
           "false",
-          "--declarationDir",
           "--project",
           tsConfigPath,
+          "--declarationDir",
           path.join(out, "dist-types/")
         ],
         { cwd }


### PR DESCRIPTION
In commit c3c6799, which added the `tsconfig` option to the `types` plugin, the `--project` option to the `tsc` call was accidentally added between `--declarationDir` and the declaration directory. This means thatTypeScript declaration file extraction is currently completely broken.

This commit brings the arguments into the correct order.