### PR TITLE
add pika-plugin-unpkg-field to community plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,4 @@ This repo contains the official build plugins for @pika/pack.
 - [`@ryaninvents/plugin-bundle-dependencies`](https://www.npmjs.com/package/@ryaninvents/plugin-bundle-dependencies): zip your package's dependencies.
 - [`@ryaninvents/plugin-bundle-nextjs`](https://www.npmjs.com/package/@ryaninvents/plugin-bundle-nextjs): Package a Next.js app for AWS Lambda.
 - [`pika-plugin-minify`](https://www.npmjs.com/package/pika-plugin-minify): Minifies your index.js files in `/pkg/*` using terser.
+- [`pika-plugin-unpkg-field`](https://www.npmjs.com/package/pika-plugin-unpkg-field): sets the `"unpkg"` field in `pkg/package.json`.


### PR DESCRIPTION
I’m not sure if that qualifies, it’s super tiny module. But it’s useful to allow people load the module directly from https://unpkg.com/