### PR TITLE
add support for `"browser"` field in package.json

### DIFF
--- a/packages/plugin-bundle-web/src/index.ts
+++ b/packages/plugin-bundle-web/src/index.ts
@@ -26,6 +26,7 @@ export async function build({out, options, reporter}: BuilderOptions): Promise<v
     plugins: [
       rollupNodeResolve({
         preferBuiltins: true,
+        browser: options.browser
       }),
       rollupCommonJs({
         include: 'node_modules/**',


### PR DESCRIPTION
closes #45. I tested it locally by directly editing `node_modules/@pika/plugin-bundle-web/dist-node/index.js`

```js
{
  "name": "example-package-json",
  "version": "1.0.0",
  "@pika/pack": {
    "pipeline": [
      ["@pika/plugin-standard-pkg"],
      ["@pika/plugin-build-web"],
      ["@pika/plugin-bundle-web", { "browser": true }]
    ]
  }
}
```