### PR TITLE
Use local browserslist configs for plugin-build-web

### DIFF
--- a/packages/plugin-build-web/src/index.ts
+++ b/packages/plugin-build-web/src/index.ts
@@ -36,7 +36,6 @@ export async function build({out, reporter}: BuilderOptions): Promise<void> {
             babelPresetEnv,
             {
               modules: false,
-              targets: {esmodules: true},
               spec: true,
             },
           ],


### PR DESCRIPTION
Avoid setting target, instead automatically picking up local browserslist configs in `package.json`, `browserslistrc` files, etc.
The `module` field in `package.json` simply indicates that it points to code that uses ES modules, most projects will still want to transpile according to their project's browser requirements.

See https://github.com/rollup/rollup/wiki/pkg.module#wait-it-just-means-import-and-export--not-other-future-javascript-features

The `esmodules: true` option can (and probably should) be used in the user's root babel config if that's what they want, and `build-web` uses the established way (browserslist) of configuring the output.