### PR TITLE
Remove spec option from babel-preset-env

### DIFF
--- a/packages/plugin-build-web/src/index.ts
+++ b/packages/plugin-build-web/src/index.ts
@@ -37,7 +37,6 @@ export async function build({out, reporter}: BuilderOptions): Promise<void> {
             {
               modules: false,
               targets: {esmodules: true},
-              spec: true,
             },
           ],
         ],


### PR DESCRIPTION
It makes code both slower (each arrow function gets an extra function-call inside it to validate `this` for instance) and significantly larger.