### PR TITLE
Do not require deno to be installed for deno build

### DIFF
--- a/packages/plugin-build-deno/src/index.ts
+++ b/packages/plugin-build-deno/src/index.ts
@@ -3,16 +3,7 @@ import fs from 'fs';
 import util from 'util';
 import glob from 'glob';
 import mkdirp from 'mkdirp';
-import {BuilderOptions, MessageError} from '@pika/types';
-import execa from 'execa';
-
-export async function beforeBuild({cwd}: BuilderOptions) {
-  return execa('deno', ['--version'], {cwd}).catch(err => {
-    throw new MessageError(
-      '@pika/plugin-build-deno can only handle packages already written for Deno. Exiting because we could not find deno on your machine.',
-    );
-  });
-}
+import {BuilderOptions} from '@pika/types';
 
 export async function manifest(manifest, {cwd}: BuilderOptions): Promise<void> {
   const pathToTsconfig = path.join(cwd, 'tsconfig.json');


### PR DESCRIPTION
Currently the deno build step will fail with newer versions of deno, as `deno --version` is no longer a valid command, and has changed to simply `deno version`. 

At the moment, there does not seem to be a good reason to restrict this build to only platforms where deno is install so I removed the whole pre check. 

If you disagree I can update it to instead run `deno version`

Thanks for such a lovely product 😍 