### PR TITLE
Add pika-plugin-pkg-node to community plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,4 @@ This repo contains the official build plugins for @pika/pack.
 - [`@ryaninvents/plugin-bundle-nextjs`](https://www.npmjs.com/package/@ryaninvents/plugin-bundle-nextjs): Package a Next.js app for AWS Lambda.
 - [`pika-plugin-minify`](https://www.npmjs.com/package/pika-plugin-minify): Minifies your index.js files in `/pkg/*` using terser.
 - [`pika-plugin-unpkg-field`](https://www.npmjs.com/package/pika-plugin-unpkg-field): sets the `"unpkg"` field in `pkg/package.json`.
+- [`pika-plugin-pkg-node`](https://www.npmjs.com/package/pika-plugin-pkg-node): Package a Node.js app into an executable.


### PR DESCRIPTION
Hi,

I'm not sure this plugin is appropriate and in the spirit of Pika plugins, but it can be useful for someone. For example, you can package a CLI app as a native executable that can be run without installing Node.js first.

If you want to see it in action, you can have a look at this example: https://github.com/kevinpollet/pika-plugin-pkg-node/tree/master/examples/hello-pika-cli