### PR TITLE
fix: numbering typo

### DIFF
--- a/packages/plugin-build-types/README.md
+++ b/packages/plugin-build-types/README.md
@@ -43,4 +43,4 @@ For more information about @pika/pack & help getting started, [check out the mai
   - If your package is written in TypeScript: Types are automatically generated from your source.
   - If your package already includes custom-written type definitions: These files are automatically copied into your package build.
   - Otherwise: Automatically generate definitions from your JavaScript source. *(Note that this currently requires that you include `@pika/plugin-build-node` or some other Node.js build earlier in the pipeline.)*
-1. Adds a "types" entrypoint to your built `package.json` manifest.
+2. Adds a "types" entrypoint to your built `package.json` manifest.


### PR DESCRIPTION
I also noticed that `@pika/plugin-build-types` is a bit confusing because it is actually not needed in a TS project when using `@pika/plugin-ts-standard-pkg`. Did I get this right? Maybe it could be specified in the top note about the package in the readme, not only in the `Results` list at the bottom.