### PR TITLE
use rollup-plugin-babel for build-web

### DIFF
--- a/packages/plugin-build-web/package.json
+++ b/packages/plugin-build-web/package.json
@@ -26,7 +26,8 @@
   },
   "dependencies": {
     "@types/node": "^10.12.18",
-    "rollup": "^1.1.0"
+    "rollup": "^1.1.0",
+    "rollup-plugin-babel": "^4.3.0"
   },
   "devDependencies": {
     "@pika/pack": "^0.5.0",

--- a/packages/plugin-build-web/src/index.ts
+++ b/packages/plugin-build-web/src/index.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import fs from 'fs';
 import {BuilderOptions, MessageError} from '@pika/types';
 import {rollup} from 'rollup';
+import rollupBabel from 'rollup-plugin-babel';
 
 export async function beforeJob({out}: BuilderOptions) {
   const srcDirectory = path.join(out, 'dist-src/');
@@ -18,12 +19,16 @@ export function manifest(manifest) {
   manifest.module = manifest.module || 'dist-web/index.js';
 }
 
-export async function build({out, options, reporter}: BuilderOptions): Promise<void> {
+export async function build({out, cwd, options, reporter}: BuilderOptions): Promise<void> {
   const writeToWeb = path.join(out, 'dist-web', 'index.js');
 
   const result = await rollup({
-    input: path.join(out, 'dist-src/index.js'),
-    plugins: [],
+    input: options.input || path.join(cwd, `src/index.js`),
+    plugins: [
+      rollupBabel({
+        exclude: 'node_modules/**',
+      }),
+    ],
     onwarn: ((warning, defaultOnWarnHandler) => {
       // // Unresolved external imports are expected
       if (


### PR DESCRIPTION
use https://github.com/rollup/rollup-plugin-babel to deduplicate helpers

```
In some cases Babel uses helpers to avoid repeating chunks of code – for example, if you use the class keyword, it will use a classCallCheck function to ensure that the class is instantiated correctly.

By default, those helpers will be inserted at the top of the file being transformed, which can lead to duplication. This rollup plugin automatically deduplicates those helpers, keeping only one copy of each one used in the output bundle. Rollup will combine the helpers in a single block at the top of your bundle. To achieve the same in Babel 6 you must use the external-helpers plugin.
```