### PR TITLE
fix(plugin-bundle-web): minify option false should disable minifier 

### DIFF
--- a/packages/plugin-build-deno/pkg/dist-types/index.d.ts
+++ b/packages/plugin-build-deno/pkg/dist-types/index.d.ts
@@ -1,3 +1,3 @@
-import { BuilderOptions } from '@pika/types';
-export declare function manifest(manifest: any, { cwd }: BuilderOptions): Promise<void>;
-export declare function build({ cwd, out, options }: BuilderOptions): Promise<void>;
+import {BuilderOptions} from '@pika/types';
+export declare function manifest(manifest: any, {cwd}: BuilderOptions): Promise<void>;
+export declare function build({cwd, out, options}: BuilderOptions): Promise<void>;

--- a/packages/plugin-build-node/custom-types/babel-plugin-dynamic-import-node-babel-7.d.ts
+++ b/packages/plugin-build-node/custom-types/babel-plugin-dynamic-import-node-babel-7.d.ts
@@ -1,3 +1,3 @@
 declare module 'babel-plugin-dynamic-import-node-babel-7' {
-    export default function(): void;
+  export default function(): void;
 }

--- a/packages/plugin-build-node/pkg/dist-types/index.d.ts
+++ b/packages/plugin-build-node/pkg/dist-types/index.d.ts
@@ -1,4 +1,4 @@
-import { BuilderOptions } from '@pika/types';
+import {BuilderOptions} from '@pika/types';
 export declare function manifest(manifest: any): void;
-export declare function beforeJob({ out }: BuilderOptions): Promise<void>;
-export declare function build({ out, reporter, options }: BuilderOptions): Promise<void>;
+export declare function beforeJob({out}: BuilderOptions): Promise<void>;
+export declare function build({out, reporter, options}: BuilderOptions): Promise<void>;

--- a/packages/plugin-build-types/pkg/dist-types/index.d.ts
+++ b/packages/plugin-build-types/pkg/dist-types/index.d.ts
@@ -1,4 +1,4 @@
-import { BuilderOptions } from '@pika/types';
+import {BuilderOptions} from '@pika/types';
 export declare function manifest(manifest: any): void;
-export declare function beforeBuild({ options, cwd }: BuilderOptions): Promise<void>;
-export declare function build({ cwd, out, options, reporter }: BuilderOptions): Promise<void>;
+export declare function beforeBuild({options, cwd}: BuilderOptions): Promise<void>;
+export declare function build({cwd, out, options, reporter}: BuilderOptions): Promise<void>;

--- a/packages/plugin-build-umd/pkg/dist-types/index.d.ts
+++ b/packages/plugin-build-umd/pkg/dist-types/index.d.ts
@@ -1,4 +1,4 @@
-import { BuilderOptions } from '@pika/types';
-export declare function beforeJob({ out }: BuilderOptions): Promise<void>;
+import {BuilderOptions} from '@pika/types';
+export declare function beforeJob({out}: BuilderOptions): Promise<void>;
 export declare function manifest(manifest: any): void;
-export declare function build({ out, reporter, options }: BuilderOptions): Promise<void>;
+export declare function build({out, reporter, options}: BuilderOptions): Promise<void>;

--- a/packages/plugin-build-web/pkg/dist-types/index.d.ts
+++ b/packages/plugin-build-web/pkg/dist-types/index.d.ts
@@ -1,4 +1,4 @@
-import { BuilderOptions } from '@pika/types';
-export declare function beforeJob({ out }: BuilderOptions): Promise<void>;
+import {BuilderOptions} from '@pika/types';
+export declare function beforeJob({out}: BuilderOptions): Promise<void>;
 export declare function manifest(manifest: any): void;
-export declare function build({ out, options, reporter }: BuilderOptions): Promise<void>;
+export declare function build({out, options, reporter}: BuilderOptions): Promise<void>;

--- a/packages/plugin-bundle-node/pkg/dist-types/index.d.ts
+++ b/packages/plugin-bundle-node/pkg/dist-types/index.d.ts
@@ -1,3 +1,3 @@
-import { BuilderOptions } from '@pika/types';
-export declare function beforeJob({ out }: BuilderOptions): Promise<void>;
-export declare function build({ out, reporter, options }: BuilderOptions): Promise<void>;
+import {BuilderOptions} from '@pika/types';
+export declare function beforeJob({out}: BuilderOptions): Promise<void>;
+export declare function build({out, reporter, options}: BuilderOptions): Promise<void>;

--- a/packages/plugin-bundle-types/pkg/dist-types/index.d.ts
+++ b/packages/plugin-bundle-types/pkg/dist-types/index.d.ts
@@ -1,5 +1,5 @@
-import { BuilderOptions } from '@pika/types';
-export declare function beforeBuild({ cwd, options }: BuilderOptions): Promise<void>;
-export declare function beforeJob({ out }: BuilderOptions): Promise<void>;
+import {BuilderOptions} from '@pika/types';
+export declare function beforeBuild({cwd, options}: BuilderOptions): Promise<void>;
+export declare function beforeJob({out}: BuilderOptions): Promise<void>;
 export declare function manifest(newManifest: any): any;
-export declare function build({ cwd, out, options, reporter, manifest }: BuilderOptions): Promise<void>;
+export declare function build({cwd, out, options, reporter, manifest}: BuilderOptions): Promise<void>;

--- a/packages/plugin-bundle-web/pkg/dist-types/index.d.ts
+++ b/packages/plugin-bundle-web/pkg/dist-types/index.d.ts
@@ -1,4 +1,4 @@
-import { BuilderOptions } from '@pika/types';
-export declare function beforeJob({ out }: BuilderOptions): Promise<void>;
-export declare function manifest(manifest: any, { options }: BuilderOptions): void;
-export declare function build({ out, options, reporter }: BuilderOptions): Promise<void>;
+import {BuilderOptions} from '@pika/types';
+export declare function beforeJob({out}: BuilderOptions): Promise<void>;
+export declare function manifest(manifest: any, {options}: BuilderOptions): void;
+export declare function build({out, options, reporter}: BuilderOptions): Promise<void>;

--- a/packages/plugin-bundle-web/src/index.ts
+++ b/packages/plugin-bundle-web/src/index.ts
@@ -73,7 +73,7 @@ export async function build({out, options, reporter}: BuilderOptions): Promise<v
       }),
       options.minify !== false
         ? rollupTerser(typeof options.minify === 'object' ? options.minify : undefined)
-        : undefined,
+        : {},
     ],
   });
 

--- a/packages/plugin-bundle-web/src/index.ts
+++ b/packages/plugin-bundle-web/src/index.ts
@@ -28,9 +28,9 @@ export async function beforeJob({out}: BuilderOptions) {
 export function manifest(manifest, {options}: BuilderOptions) {
   if (options.entrypoint) {
     if (options.entrypoint instanceof Array) {
-      options.entrypoint.forEach((entrypoint) => {
+      options.entrypoint.forEach(entrypoint => {
         manifest[entrypoint] = 'dist-web/index.bundled.js';
-      })
+      });
     } else {
       manifest[options.entrypoint] = 'dist-web/index.bundled.js';
     }
@@ -71,9 +71,7 @@ export async function build({out, options, reporter}: BuilderOptions): Promise<v
         ],
         plugins: [babelPluginDynamicImportSyntax, babelPluginImportMetaSyntax],
       }),
-      options.minify !== false
-        ? rollupTerser(typeof options.minify === 'object' ? options.minify : undefined)
-        : {},
+      options.minify !== false ? rollupTerser(typeof options.minify === 'object' ? options.minify : undefined) : {},
     ],
   });
 

--- a/packages/plugin-copy-assets/pkg/dist-types/index.d.ts
+++ b/packages/plugin-copy-assets/pkg/dist-types/index.d.ts
@@ -1,4 +1,4 @@
-import { BuilderOptions } from '@pika/types';
-export declare function manifest(manifest: any, { options }: BuilderOptions): void;
-export declare function beforeJob({ cwd, options }: BuilderOptions): Promise<void>;
-export declare function build({ out, cwd, reporter, options }: BuilderOptions): Promise<void>;
+import {BuilderOptions} from '@pika/types';
+export declare function manifest(manifest: any, {options}: BuilderOptions): void;
+export declare function beforeJob({cwd, options}: BuilderOptions): Promise<void>;
+export declare function build({out, cwd, reporter, options}: BuilderOptions): Promise<void>;

--- a/packages/plugin-source-bucklescript/pkg/dist-types/index.d.ts
+++ b/packages/plugin-source-bucklescript/pkg/dist-types/index.d.ts
@@ -1,6 +1,4 @@
-import { BuilderOptions } from '@pika/types';
-export declare function validate({ cwd }: {
-    cwd: any;
-}): boolean;
+import {BuilderOptions} from '@pika/types';
+export declare function validate({cwd}: {cwd: any}): boolean;
 export declare function manifest(newManifest: any): any;
-export declare function build({ cwd, out, reporter }: BuilderOptions): Promise<void>;
+export declare function build({cwd, out, reporter}: BuilderOptions): Promise<void>;

--- a/packages/plugin-standard-pkg/pkg/dist-types/index.d.ts
+++ b/packages/plugin-standard-pkg/pkg/dist-types/index.d.ts
@@ -1,5 +1,5 @@
-import { BuilderOptions } from '@pika/types';
-export declare function beforeJob({ cwd }: BuilderOptions): Promise<void>;
-export declare function afterJob({ out, reporter }: BuilderOptions): Promise<void>;
+import {BuilderOptions} from '@pika/types';
+export declare function beforeJob({cwd}: BuilderOptions): Promise<void>;
+export declare function afterJob({out, reporter}: BuilderOptions): Promise<void>;
 export declare function manifest(newManifest: any): any;
-export declare function build({ cwd, out, options, reporter }: BuilderOptions): Promise<void>;
+export declare function build({cwd, out, options, reporter}: BuilderOptions): Promise<void>;

--- a/packages/plugin-ts-standard-pkg/pkg/dist-types/index.d.ts
+++ b/packages/plugin-ts-standard-pkg/pkg/dist-types/index.d.ts
@@ -1,6 +1,6 @@
-import { BuilderOptions } from '@pika/types';
-export declare function beforeBuild({ cwd, options, reporter }: BuilderOptions): Promise<void>;
-export declare function beforeJob({ cwd }: BuilderOptions): Promise<void>;
-export declare function afterJob({ out, reporter }: BuilderOptions): Promise<void>;
+import {BuilderOptions} from '@pika/types';
+export declare function beforeBuild({cwd, options, reporter}: BuilderOptions): Promise<void>;
+export declare function beforeJob({cwd}: BuilderOptions): Promise<void>;
+export declare function afterJob({out, reporter}: BuilderOptions): Promise<void>;
 export declare function manifest(newManifest: any): any;
-export declare function build({ cwd, out, options, reporter }: BuilderOptions): Promise<void>;
+export declare function build({cwd, out, options, reporter}: BuilderOptions): Promise<void>;

--- a/packages/types/dist-types/index.d.ts
+++ b/packages/types/dist-types/index.d.ts
@@ -1,24 +1,24 @@
 export declare type BuilderOptions = {
-    cwd: string;
-    out: string;
+  cwd: string;
+  out: string;
+  options: any;
+  src: {
+    loc: string;
+    entrypoint: string | string[];
     options: any;
-    src: {
-        loc: string;
-        entrypoint: string | string[];
-        options: any;
-        files: Array<string>;
-    };
-    watch: string | undefined;
-    reporter: {
-        info: (msg: string) => void;
-        warning: (msg: string) => void;
-        success: (msg: string) => void;
-        created: (file: string, entrypoint?: string) => void;
-    };
-    isFull: boolean;
-    manifest: any;
-    rollup: any;
+    files: Array<string>;
+  };
+  watch: string | undefined;
+  reporter: {
+    info: (msg: string) => void;
+    warning: (msg: string) => void;
+    success: (msg: string) => void;
+    created: (file: string, entrypoint?: string) => void;
+  };
+  isFull: boolean;
+  manifest: any;
+  rollup: any;
 };
 export declare class MessageError extends Error {
-    constructor(msg: string);
+  constructor(msg: string);
 }

--- a/packages/types/pkg/dist-types/index.d.ts
+++ b/packages/types/pkg/dist-types/index.d.ts
@@ -1,24 +1,24 @@
 export declare type BuilderOptions = {
-    cwd: string;
-    out: string;
+  cwd: string;
+  out: string;
+  options: any;
+  src: {
+    loc: string;
+    entrypoint: string | string[];
     options: any;
-    src: {
-        loc: string;
-        entrypoint: string | string[];
-        options: any;
-        files: Array<string>;
-    };
-    watch: string | undefined;
-    reporter: {
-        info: (msg: string) => void;
-        warning: (msg: string) => void;
-        success: (msg: string) => void;
-        created: (file: string, entrypoint?: string) => void;
-    };
-    isFull: boolean;
-    manifest: any;
-    rollup: any;
+    files: Array<string>;
+  };
+  watch: string | undefined;
+  reporter: {
+    info: (msg: string) => void;
+    warning: (msg: string) => void;
+    success: (msg: string) => void;
+    created: (file: string, entrypoint?: string) => void;
+  };
+  isFull: boolean;
+  manifest: any;
+  rollup: any;
 };
 export declare class MessageError extends Error {
-    constructor(msg: string);
+  constructor(msg: string);
 }


### PR DESCRIPTION
Currently setting `{minify: false}` is resulting in the exception
```
TypeError: Cannot read property 'resolveId' of undefined
```

This is because rollup expects an empty object when disabling a plugin (https://github.com/rollup/rollup-plugin-commonjs/blob/v9.3.4/src/resolve-id.js#L50).
This replaces `undefined` with `{}` to resolve the error.