### PR TITLE
Add license to packages

### DIFF
--- a/packages/babel-plugin-esm-import-rewrite/package.json
+++ b/packages/babel-plugin-esm-import-rewrite/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@pika/babel-plugin-esm-import-rewrite",
+  "license": "MIT",
   "version": "0.6.0",
   "main": "pkg/dist-node/index.js",
   "publishConfig": {

--- a/packages/babel-plugin-esm-import-rewrite/pkg/package.json
+++ b/packages/babel-plugin-esm-import-rewrite/pkg/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@pika/babel-plugin-esm-import-rewrite",
   "version": "0.6.0",
+  "license": "MIT",
   "files": [
     "dist-*/",
     "bin/"

--- a/packages/plugin-build-deno/package.json
+++ b/packages/plugin-build-deno/package.json
@@ -2,6 +2,7 @@
   "name": "@pika/plugin-build-deno",
   "version": "0.6.0",
   "description": "A @pika/pack plugin: Adds a TypeScript distribution to your package, built to run on Deno.",
+  "license": "MIT",
   "main": "pkg/dist-node/index.js",
   "homepage": "https://www.pikapkg.com",
   "repository": {

--- a/packages/plugin-build-deno/pkg/package.json
+++ b/packages/plugin-build-deno/pkg/package.json
@@ -2,6 +2,7 @@
   "name": "@pika/plugin-build-deno",
   "description": "A @pika/pack plugin: Adds a TypeScript distribution to your package, built to run on Deno.",
   "version": "0.6.0",
+  "license": "MIT",
   "files": [
     "dist-*/",
     "bin/"

--- a/packages/plugin-build-node/package.json
+++ b/packages/plugin-build-node/package.json
@@ -2,6 +2,7 @@
   "name": "@pika/plugin-build-node",
   "version": "0.6.0",
   "description": "A @pika/pack plugin: Adds a Node.js distribution to your package, built & optimized to run on Node.js.",
+  "license": "MIT",
   "main": "pkg/dist-node/index.js",
   "homepage": "https://www.pikapkg.com",
   "repository": {

--- a/packages/plugin-build-node/pkg/package.json
+++ b/packages/plugin-build-node/pkg/package.json
@@ -2,6 +2,7 @@
   "name": "@pika/plugin-build-node",
   "description": "A @pika/pack plugin: Adds a Node.js distribution to your package, built & optimized to run on Node.js.",
   "version": "0.6.0",
+  "license": "MIT",
   "files": [
     "dist-*/",
     "bin/"

--- a/packages/plugin-build-types/package.json
+++ b/packages/plugin-build-types/package.json
@@ -2,6 +2,7 @@
   "name": "@pika/plugin-build-types",
   "version": "0.6.0",
   "description": "A @pika/pack plugin: Adds TypeScript type definitions to your package build.",
+  "license": "MIT",
   "main": "pkg/dist-node/index.js",
   "homepage": "https://www.pikapkg.com",
   "repository": {

--- a/packages/plugin-build-types/pkg/package.json
+++ b/packages/plugin-build-types/pkg/package.json
@@ -2,6 +2,7 @@
   "name": "@pika/plugin-build-types",
   "description": "A @pika/pack plugin: Adds TypeScript type definitions to your package build.",
   "version": "0.6.0",
+  "license": "MIT",
   "files": [
     "dist-*/",
     "bin/"

--- a/packages/plugin-build-umd/package.json
+++ b/packages/plugin-build-umd/package.json
@@ -2,6 +2,7 @@
   "name": "@pika/plugin-build-umd",
   "version": "0.6.0",
   "description": "A @pika/pack plugin: Adds a UMD distribution to your package, built to be flexible & run on legacy browsers & environments.",
+  "license": "MIT",
   "main": "pkg/dist-node/index.js",
   "homepage": "https://www.pikapkg.com",
   "repository": {

--- a/packages/plugin-build-umd/pkg/package.json
+++ b/packages/plugin-build-umd/pkg/package.json
@@ -2,6 +2,7 @@
   "name": "@pika/plugin-build-umd",
   "description": "A @pika/pack plugin: Adds a UMD distribution to your package, built to be flexible & run on legacy browsers & environments.",
   "version": "0.6.0",
+  "license": "MIT",
   "files": [
     "dist-*/",
     "bin/"

--- a/packages/plugin-build-web/package.json
+++ b/packages/plugin-build-web/package.json
@@ -2,6 +2,7 @@
   "name": "@pika/plugin-build-web",
   "version": "0.6.0",
   "description": "A @pika/pack plugin:  Adds an ESM distribution to your package, built & optimized to run in most web browsers (and bundlers).",
+  "license": "MIT",
   "main": "pkg/dist-node/index.js",
   "homepage": "https://www.pikapkg.com",
   "repository": {

--- a/packages/plugin-build-web/pkg/package.json
+++ b/packages/plugin-build-web/pkg/package.json
@@ -2,6 +2,7 @@
   "name": "@pika/plugin-build-web",
   "description": "A @pika/pack plugin:  Adds an ESM distribution to your package, built & optimized to run in most web browsers (and bundlers).",
   "version": "0.6.0",
+  "license": "MIT",
   "files": [
     "dist-*/",
     "bin/"

--- a/packages/plugin-bundle-node/package.json
+++ b/packages/plugin-bundle-node/package.json
@@ -2,6 +2,7 @@
   "name": "@pika/plugin-bundle-node",
   "version": "0.6.0",
   "description": "A @pika/pack plugin: Adds a bundled Node.js distribution to your package.",
+  "license": "MIT",
   "main": "pkg/dist-node/index.js",
   "homepage": "https://www.pikapkg.com",
   "repository": {

--- a/packages/plugin-bundle-node/pkg/package.json
+++ b/packages/plugin-bundle-node/pkg/package.json
@@ -2,6 +2,7 @@
   "name": "@pika/plugin-bundle-node",
   "description": "A @pika/pack plugin: Adds a bundled Node.js distribution to your package.",
   "version": "0.6.0",
+  "license": "MIT",
   "files": [
     "dist-*/",
     "bin/"

--- a/packages/plugin-bundle-types/package.json
+++ b/packages/plugin-bundle-types/package.json
@@ -2,6 +2,7 @@
   "name": "@pika/plugin-bundle-types",
   "version": "0.6.0",
   "description": "A @pika/pack plugin: Bundle & tree-shake all TypeScript definitions into a single file.",
+  "license": "MIT",
   "main": "pkg/dist-node/index.js",
   "homepage": "https://www.pikapkg.com",
   "repository": {

--- a/packages/plugin-bundle-types/pkg/package.json
+++ b/packages/plugin-bundle-types/pkg/package.json
@@ -2,6 +2,7 @@
   "name": "@pika/plugin-bundle-types",
   "description": "A @pika/pack plugin: Bundle & tree-shake all TypeScript definitions into a single file.",
   "version": "0.6.0",
+  "license": "MIT",
   "files": [
     "dist-*/",
     "bin/"

--- a/packages/plugin-bundle-web/package.json
+++ b/packages/plugin-bundle-web/package.json
@@ -2,6 +2,7 @@
   "name": "@pika/plugin-bundle-web",
   "version": "0.6.0",
   "description": "A @pika/pack plugin: Adds a bundled Web distribution to your package, built & optimized to run in most web browsers (and bundlers).",
+  "license": "MIT",
   "main": "pkg/dist-node/index.js",
   "homepage": "https://www.pikapkg.com",
   "repository": {

--- a/packages/plugin-bundle-web/pkg/package.json
+++ b/packages/plugin-bundle-web/pkg/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@pika/plugin-bundle-web",
   "description": "A @pika/pack plugin: Adds a bundled Web distribution to your package, built & optimized to run in most web browsers (and bundlers).",
+  "license": "MIT",
   "version": "0.6.0",
   "files": [
     "dist-*/",

--- a/packages/plugin-copy-assets/package.json
+++ b/packages/plugin-copy-assets/package.json
@@ -2,6 +2,7 @@
   "name": "@pika/plugin-copy-assets",
   "version": "0.6.0",
   "description": "A @pika/pack plugin: Copies static assets into your built package directory.",
+  "license": "MIT",
   "main": "pkg/dist-node/index.js",
   "homepage": "https://www.pikapkg.com",
   "repository": {

--- a/packages/plugin-copy-assets/pkg/package.json
+++ b/packages/plugin-copy-assets/pkg/package.json
@@ -2,6 +2,7 @@
   "name": "@pika/plugin-copy-assets",
   "description": "A @pika/pack plugin: Copies static assets into your built package directory.",
   "version": "0.6.0",
+  "license": "MIT",
   "files": [
     "dist-*/",
     "bin/"

--- a/packages/plugin-simple-bin/package.json
+++ b/packages/plugin-simple-bin/package.json
@@ -2,6 +2,7 @@
   "name": "@pika/plugin-simple-bin",
   "version": "0.6.0",
   "description": "A @pika/pack plugin: Adds a simple CLI wrapper.",
+  "license": "MIT",
   "main": "pkg/dist-node/index.js",
   "homepage": "https://www.pikapkg.com",
   "repository": {

--- a/packages/plugin-simple-bin/pkg/package.json
+++ b/packages/plugin-simple-bin/pkg/package.json
@@ -2,6 +2,7 @@
   "name": "@pika/plugin-simple-bin",
   "description": "A @pika/pack plugin: Adds a simple CLI wrapper.",
   "version": "0.6.0",
+  "license": "MIT",
   "files": [
     "dist-*/",
     "bin/"

--- a/packages/plugin-source-bucklescript/package.json
+++ b/packages/plugin-source-bucklescript/package.json
@@ -2,6 +2,7 @@
   "name": "@pika/plugin-source-bucklescript",
   "version": "0.6.0",
   "description": "A @pika/pack plugin: ",
+  "license": "MIT",
   "main": "pkg/dist-node/index.js",
   "homepage": "https://www.pikapkg.com",
   "repository": {

--- a/packages/plugin-source-bucklescript/pkg/package.json
+++ b/packages/plugin-source-bucklescript/pkg/package.json
@@ -2,6 +2,7 @@
   "name": "@pika/plugin-source-bucklescript",
   "description": "A @pika/pack plugin: ",
   "version": "0.6.0",
+  "license": "MIT",
   "files": [
     "dist-*/",
     "bin/"

--- a/packages/plugin-standard-pkg/package.json
+++ b/packages/plugin-standard-pkg/package.json
@@ -2,6 +2,7 @@
   "name": "@pika/plugin-standard-pkg",
   "version": "0.6.0",
   "description": "A @pika/pack plugin: Builds your package source as standard, ES2018 JavaScript.",
+  "license": "MIT",
   "main": "pkg/dist-node/index.js",
   "homepage": "https://www.pikapkg.com",
   "repository": {

--- a/packages/plugin-standard-pkg/pkg/package.json
+++ b/packages/plugin-standard-pkg/pkg/package.json
@@ -2,6 +2,7 @@
   "name": "@pika/plugin-standard-pkg",
   "description": "A @pika/pack plugin: Builds your package source as standard, ES2018 JavaScript.",
   "version": "0.6.0",
+  "license": "MIT",
   "files": [
     "dist-*/",
     "bin/"

--- a/packages/plugin-ts-standard-pkg/package.json
+++ b/packages/plugin-ts-standard-pkg/package.json
@@ -2,6 +2,7 @@
   "name": "@pika/plugin-ts-standard-pkg",
   "version": "0.6.0",
   "description": "A @pika/pack plugin: Builds your TypeScript package source as standard, ES2018 JavaScript.",
+  "license": "MIT",
   "main": "pkg/dist-node/index.js",
   "homepage": "https://www.pikapkg.com",
   "repository": {

--- a/packages/plugin-ts-standard-pkg/pkg/package.json
+++ b/packages/plugin-ts-standard-pkg/pkg/package.json
@@ -2,6 +2,7 @@
   "name": "@pika/plugin-ts-standard-pkg",
   "description": "A @pika/pack plugin: Builds your TypeScript package source as standard, ES2018 JavaScript.",
   "version": "0.6.0",
+  "license": "MIT",
   "files": [
     "dist-*/",
     "bin/"

--- a/packages/plugin-wasm-assemblyscript/package.json
+++ b/packages/plugin-wasm-assemblyscript/package.json
@@ -3,6 +3,7 @@
   "version": "0.6.0",
   "description": "A @pika/pack plugin: Builds TypeScript as WASM via AssemblyScript.",
   "main": "pkg/dist-node/index.js",
+  "license": "MIT",
   "homepage": "https://www.pikapkg.com",
   "repository": {
     "type": "git",

--- a/packages/plugin-wasm-assemblyscript/pkg/package.json
+++ b/packages/plugin-wasm-assemblyscript/pkg/package.json
@@ -2,6 +2,7 @@
   "name": "@pika/plugin-wasm-assemblyscript",
   "description": "A @pika/pack plugin: Builds TypeScript as WASM via AssemblyScript.",
   "version": "0.6.0",
+  "license": "MIT",
   "files": [
     "dist-*/",
     "bin/"

--- a/packages/plugin-wasm-bindings/package.json
+++ b/packages/plugin-wasm-bindings/package.json
@@ -2,6 +2,7 @@
   "name": "@pika/plugin-wasm-bindings",
   "version": "0.6.0",
   "description": "A @pika/pack plugin: adds simple JavaScript bindings that work with any WASM file.",
+  "license": "MIT",
   "main": "pkg/dist-node/index.js",
   "homepage": "https://www.pikapkg.com",
   "repository": {

--- a/packages/plugin-wasm-bindings/pkg/package.json
+++ b/packages/plugin-wasm-bindings/pkg/package.json
@@ -2,6 +2,7 @@
   "name": "@pika/plugin-wasm-bindings",
   "description": "A @pika/pack plugin: adds simple JavaScript bindings that work with any WASM file.",
   "version": "0.6.0",
+  "license": "MIT",
   "files": [
     "dist-*/",
     "bin/"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@pika/types",
   "version": "0.6.0",
+  "license": "MIT",
   "pika": true,
   "keywords": [
     "pika-pkg"

--- a/packages/types/pkg/package.json
+++ b/packages/types/pkg/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@pika/types",
   "version": "0.6.0",
+  "license": "MIT",
   "pika": true,
   "files": [
     "dist-*/",


### PR DESCRIPTION
Add MIT license to packages (`package.json`). This fixes problems with some dependency analyzers.