### PR TITLE
let node resolve tsc path

### DIFF
--- a/packages/plugin-build-types/src/index.ts
+++ b/packages/plugin-build-types/src/index.ts
@@ -9,9 +9,12 @@ function getTsConfigPath(options, cwd) {
 }
 
 function getTscBin(cwd) {
-  return require.resolve('typescript/bin/tsc', {
-    paths: [cwd],
-  });
+  try {
+    return require.resolve('typescript/bin/tsc', {paths: [cwd]});
+  } catch (err) {
+    // ignore err
+    return null;
+  }
 }
 
 export function manifest(manifest) {
@@ -27,7 +30,6 @@ export async function beforeBuild({options, cwd}: BuilderOptions) {
 
 export async function build({cwd, out, options, reporter}: BuilderOptions): Promise<void> {
   await (async () => {
-    const tscBin = getTscBin(cwd);
     const writeToTypings = path.join(out, 'dist-types/index.d.ts');
     const importAsNode = path.join(out, 'dist-node', 'index.js');
 
@@ -43,7 +45,8 @@ export async function build({cwd, out, options, reporter}: BuilderOptions): Prom
     }
 
     const tsConfigPath = getTsConfigPath(options, cwd);
-    if (fs.existsSync(tscBin) && fs.existsSync(tsConfigPath)) {
+    const tscBin = getTscBin(cwd);
+    if (tscBin && fs.existsSync(tsConfigPath)) {
       await execa(
         tscBin,
         [

--- a/packages/plugin-build-types/src/index.ts
+++ b/packages/plugin-build-types/src/index.ts
@@ -8,6 +8,12 @@ function getTsConfigPath(options, cwd) {
   return path.resolve(cwd, options.tsconfig || 'tsconfig.json');
 }
 
+function getTscBin(cwd) {
+  return require.resolve('typescript/bin/tsc', {
+    paths: [cwd],
+  });
+}
+
 export function manifest(manifest) {
   manifest.types = manifest.types || 'dist-types/index.d.ts';
 }
@@ -21,7 +27,7 @@ export async function beforeBuild({options, cwd}: BuilderOptions) {
 
 export async function build({cwd, out, options, reporter}: BuilderOptions): Promise<void> {
   await (async () => {
-    const tscBin = path.join(cwd, 'node_modules/.bin/tsc');
+    const tscBin = getTscBin(cwd);
     const writeToTypings = path.join(out, 'dist-types/index.d.ts');
     const importAsNode = path.join(out, 'dist-node', 'index.js');
 

--- a/packages/plugin-ts-standard-pkg/src/index.ts
+++ b/packages/plugin-ts-standard-pkg/src/index.ts
@@ -42,9 +42,14 @@ function getTsConfigPath(options, cwd) {
   return path.resolve(cwd, options.tsconfig || 'tsconfig.json');
 }
 
+function getTscBin(cwd) {
+  return require.resolve('typescript/bin/tsc', {
+    paths: [cwd],
+  });
+}
+
 export async function beforeBuild({cwd, options, reporter}: BuilderOptions) {
-  const tscBin = path.join(cwd, 'node_modules/.bin/tsc');
-  if (!fs.existsSync(tscBin)) {
+  if (!fs.existsSync(getTscBin(cwd))) {
     throw new MessageError('"tsc" executable not found. Make sure "typescript" is installed as a project dependency.');
   }
   const tsConfigPath = getTsConfigPath(options, cwd);
@@ -91,9 +96,8 @@ export function manifest(newManifest) {
 }
 
 export async function build({cwd, out, options, reporter}: BuilderOptions): Promise<void> {
-  const tscBin = path.join(cwd, 'node_modules/.bin/tsc');
   await execa(
-    tscBin,
+    getTscBin(cwd),
     [
       '--outDir',
       path.join(out, 'dist-src/'),

--- a/packages/plugin-ts-standard-pkg/src/index.ts
+++ b/packages/plugin-ts-standard-pkg/src/index.ts
@@ -43,13 +43,16 @@ function getTsConfigPath(options, cwd) {
 }
 
 function getTscBin(cwd) {
-  return require.resolve('typescript/bin/tsc', {
-    paths: [cwd],
-  });
+  try {
+    return require.resolve('typescript/bin/tsc', {paths: [cwd]});
+  } catch (err) {
+    // ignore err
+    return null;
+  }
 }
 
 export async function beforeBuild({cwd, options, reporter}: BuilderOptions) {
-  if (!fs.existsSync(getTscBin(cwd))) {
+  if (!getTscBin(cwd)) {
     throw new MessageError('"tsc" executable not found. Make sure "typescript" is installed as a project dependency.');
   }
   const tsConfigPath = getTsConfigPath(options, cwd);


### PR DESCRIPTION
This should close #42 by letting node correctly resolve the path to `tsc`. It works for us with nested projects over at https://github.com/async-library/react-async/pull/105.