### PR TITLE
Add option for additional tsc arguments

### DIFF
--- a/packages/plugin-build-types/README.md
+++ b/packages/plugin-build-types/README.md
@@ -37,6 +37,7 @@ For more information about @pika/pack & help getting started, [check out the mai
 ## Options
 
 - `"tsconfig"`: The relative path to the `tsconfig.json` config file to use. Defaults to the top-level project TypeScript config file, if one exists.
+- `"args"`: Optional, an array of additional arguments for tsc. Example: `["--build"]`
 
 
 ## Result

--- a/packages/plugin-build-types/src/index.ts
+++ b/packages/plugin-build-types/src/index.ts
@@ -37,6 +37,7 @@ export async function build({cwd, out, options, reporter}: BuilderOptions): Prom
     }
 
     const tsConfigPath = getTsConfigPath(options, cwd);
+    const additionalArgs = options.args || [];
     if (fs.existsSync(tscBin) && fs.existsSync(tsConfigPath)) {
       await execa(
         tscBin,
@@ -49,6 +50,7 @@ export async function build({cwd, out, options, reporter}: BuilderOptions): Prom
           tsConfigPath,
           '--declarationDir',
           path.join(out, 'dist-types/'),
+          ...additionalArgs,
         ],
         {cwd},
       );

--- a/packages/plugin-ts-standard-pkg/README.md
+++ b/packages/plugin-ts-standard-pkg/README.md
@@ -38,6 +38,7 @@ For more information about @pika/pack & help getting started, [check out the mai
 This plugin runs `tsc` internally, so it supports all [tsconfig.json](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html) options defined in your project-level config file (like `compilerOptions` & `exclude`).
 
 - `"tsconfig"`: Optional, the relative path to the `tsconfig.json` config file to use. Defaults to the top-level project TypeScript config file, if one exists.
+- `"args"`: Optional, an array of additional arguments for tsc. Example: `["--build"]`
 
 
 ## Result

--- a/packages/plugin-ts-standard-pkg/src/index.ts
+++ b/packages/plugin-ts-standard-pkg/src/index.ts
@@ -92,6 +92,7 @@ export function manifest(newManifest) {
 
 export async function build({cwd, out, options, reporter}: BuilderOptions): Promise<void> {
   const tscBin = path.join(cwd, 'node_modules/.bin/tsc');
+  const additionalArgs = options.args || [];
   await execa(
     tscBin,
     [
@@ -108,6 +109,7 @@ export async function build({cwd, out, options, reporter}: BuilderOptions): Prom
       'esnext',
       '--noEmit',
       'false',
+      ...additionalArgs,
     ],
     {cwd},
   );


### PR DESCRIPTION
This closes #82.
I made the new `args` option an array to allow for multiple arguments.
Additionally I also added the option `build-types`-plugin. I'm not sure if there is a usecase for this but I think the option should be there.