### PR TITLE
Improve option.entrypoint consistency across builders

### DIFF
--- a/packages/plugin-build-deno/README.md
+++ b/packages/plugin-build-deno/README.md
@@ -36,7 +36,7 @@ For more information about @pika/pack & help getting started, [check out the mai
 
 ## Options
 
-- `"entrypoint"` (Default: `"deno"`): Customize the package.json manifest entrypoint set by this plugin. Accepts either a string or an array of strings. Changing this is not recommended for most usage.
+- `"entrypoint"` (Default: `"deno"`): Customize the package.json manifest entrypoint set by this plugin. Accepts either a string, an array of strings, or `null` to disable entrypoint. Changing this is not recommended for most usage.
 
 
 ## Result

--- a/packages/plugin-build-deno/src/index.ts
+++ b/packages/plugin-build-deno/src/index.ts
@@ -11,12 +11,14 @@ export async function manifest(manifest, {cwd, options}: BuilderOptions): Promis
   if (!fs.existsSync(pathToTsconfig)) {
     return;
   }
-  let keys = options.entrypoint || [DEFAULT_ENTRYPOINT];
-  if (typeof keys === 'string') {
-    keys = [keys];
-  }
-  for (const key of keys) {
-    manifest[key] = manifest[key] || 'dist-deno/index.ts';
+  if (options.entrypoint !== null) {
+    let keys = options.entrypoint || [DEFAULT_ENTRYPOINT];
+    if (typeof keys === 'string') {
+      keys = [keys];
+    }
+    for (const key of keys) {
+      manifest[key] = manifest[key] || 'dist-deno/index.ts';
+    }
   }
 }
 

--- a/packages/plugin-build-node/README.md
+++ b/packages/plugin-build-node/README.md
@@ -36,7 +36,7 @@ For more information about @pika/pack & help getting started, [check out the mai
 
 - `"sourcemap"` (Default: `"true"`): Adds a [source map](https://www.html5rocks.com/en/tutorials/developertools/sourcemaps/) for this build.
 - `"minNodeVersion"` (Default: `"8"`): This plugin will build your package for the current minimum [Node.js LTS](https://github.com/nodejs/Release) major version. This option allows you to target later versions of Node.js only.
-- `"entrypoint"` (Default: `"main"`): Customize the package.json manifest entrypoint set by this plugin. Accepts either a string or an array of strings. Changing this is not recommended for most usage.
+- `"entrypoint"` (Default: `"main"`): Customize the package.json manifest entrypoint set by this plugin. Accepts either a string, an array of strings, or `null` to disable entrypoint. Changing this is not recommended for most usage.
 
 
 ## Result

--- a/packages/plugin-build-node/src/index.ts
+++ b/packages/plugin-build-node/src/index.ts
@@ -13,12 +13,14 @@ const DEFAULT_ENTRYPOINT = 'main';
 const DEFAULT_MIN_NODE_VERSION = '8';
 
 export function manifest(manifest, {options}: BuilderOptions) {
-  let keys = options.entrypoint || [DEFAULT_ENTRYPOINT];
-  if (typeof keys === 'string') {
-    keys = [keys];
-  }
-  for (const key of keys) {
-    manifest[key] = manifest[key] || 'dist-node/index.js';
+  if (options.entrypoint !== null) {
+    let keys = options.entrypoint || [DEFAULT_ENTRYPOINT];
+    if (typeof keys === 'string') {
+      keys = [keys];
+    }
+    for (const key of keys) {
+      manifest[key] = manifest[key] || 'dist-node/index.js';
+    }
   }
 }
 

--- a/packages/plugin-build-types/README.md
+++ b/packages/plugin-build-types/README.md
@@ -38,7 +38,7 @@ For more information about @pika/pack & help getting started, [check out the mai
 
 - `"tsconfig"`: The relative path to the `tsconfig.json` config file to use. Defaults to the top-level project TypeScript config file, if one exists.
 - `"args"`: Optional, an array of additional arguments for tsc. Example: `["--build"]`
-- `"entrypoint"` (Default: `"types"`): Customize the package.json manifest entrypoint set by this plugin. Accepts either a string or an array of strings. Changing this is not recommended for most usage.
+- `"entrypoint"` (Default: `"types"`): Customize the package.json manifest entrypoint set by this plugin. Accepts either a string, an array of strings, or `null` to disable entrypoint. Changing this is not recommended for most usage.
 
 
 ## Result

--- a/packages/plugin-build-types/src/index.ts
+++ b/packages/plugin-build-types/src/index.ts
@@ -19,12 +19,14 @@ function getTscBin(cwd) {
 }
 
 export function manifest(manifest, {options}: BuilderOptions) {
-  let keys = options.entrypoint || [DEFAULT_ENTRYPOINT];
-  if (typeof keys === 'string') {
-    keys = [keys];
-  }
-  for (const key of keys) {
-    manifest[key] = manifest[key] || 'dist-types/index.d.ts';
+  if (options.entrypoint !== null) {
+    let keys = options.entrypoint || [DEFAULT_ENTRYPOINT];
+    if (typeof keys === 'string') {
+      keys = [keys];
+    }
+    for (const key of keys) {
+      manifest[key] = manifest[key] || 'dist-types/index.d.ts';
+    }
   }
 }
 

--- a/packages/plugin-build-umd/README.md
+++ b/packages/plugin-build-umd/README.md
@@ -36,7 +36,7 @@ For more information about @pika/pack & help getting started, [check out the mai
 
 - `"sourcemap"` (Default: `"true"`): Adds a [source map](https://www.html5rocks.com/en/tutorials/developertools/sourcemaps/) for this build.
 - `"name"` (Defaults: your package name): Sets the name that your package is attached to on the `window` object.
-- `"entrypoint"` (Default: `"umd:main"`): Customize the package.json manifest entrypoint set by this plugin. Accepts either a string or an array of strings. Changing this is not recommended for most usage.
+- `"entrypoint"` (Default: `"umd:main"`): Customize the package.json manifest entrypoint set by this plugin. Accepts either a string, an array of strings, or `null` to disable entrypoint. Changing this is not recommended for most usage.
 
 
 ## Result

--- a/packages/plugin-build-umd/src/index.ts
+++ b/packages/plugin-build-umd/src/index.ts
@@ -20,12 +20,14 @@ export async function beforeJob({out}: BuilderOptions) {
 }
 
 export function manifest(manifest, {options}: BuilderOptions) {
-  let keys = options.entrypoint || [DEFAULT_ENTRYPOINT];
-  if (typeof keys === 'string') {
-    keys = [keys];
-  }
-  for (const key of keys) {
-    manifest[key] = manifest[key] || 'dist-umd/index.js';
+  if (options.entrypoint !== null) {
+    let keys = options.entrypoint || [DEFAULT_ENTRYPOINT];
+    if (typeof keys === 'string') {
+      keys = [keys];
+    }
+    for (const key of keys) {
+      manifest[key] = manifest[key] || 'dist-umd/index.js';
+    }
   }
 }
 

--- a/packages/plugin-build-web/README.md
+++ b/packages/plugin-build-web/README.md
@@ -34,7 +34,7 @@ For more information about @pika/pack & help getting started, [check out the mai
 ## Options
 
 - `"sourcemap"` (Default: `"true"`): Adds a [source map](https://www.html5rocks.com/en/tutorials/developertools/sourcemaps/) for this build.
-- `"entrypoint"` (Default: `"module"`): Customize the package.json manifest entrypoint set by this plugin. Accepts either a string or an array of strings. Changing this is not recommended for most usage.
+- `"entrypoint"` (Default: `"module"`): Customize the package.json manifest entrypoint set by this plugin. Accepts either a string, an array of strings, or `null` to disable entrypoint. Changing this is not recommended for most usage.
 
 
 ## Result

--- a/packages/plugin-build-web/src/index.ts
+++ b/packages/plugin-build-web/src/index.ts
@@ -15,12 +15,14 @@ export async function beforeJob({out}: BuilderOptions) {
 }
 
 export function manifest(manifest, {options}: BuilderOptions) {
-  let keys = options.entrypoint || [DEFAULT_ENTRYPOINT];
-  if (typeof keys === 'string') {
-    keys = [keys];
-  }
-  for (const key of keys) {
-    manifest[key] = manifest[key] || 'dist-web/index.js';
+  if (options.entrypoint !== null) {
+    let keys = options.entrypoint || [DEFAULT_ENTRYPOINT];
+    if (typeof keys === 'string') {
+      keys = [keys];
+    }
+    for (const key of keys) {
+      manifest[key] = manifest[key] || 'dist-web/index.js';
+    }
   }
 }
 

--- a/packages/plugin-bundle-types/README.md
+++ b/packages/plugin-bundle-types/README.md
@@ -35,6 +35,7 @@ For more information about @pika/pack & help getting started, [check out the mai
 ## Options
 
 - `"tsconfig"`: The relative path to the `tsconfig.json` config file to use. Defaults to the top-level project TypeScript config file, if one exists.
+- `"entrypoint"` (Default: `"types"`): Customize the package.json manifest entrypoint set by this plugin. Accepts either a string or an array of strings. Changing this is not recommended for most usage.
 
 ## Result
 

--- a/packages/plugin-bundle-types/README.md
+++ b/packages/plugin-bundle-types/README.md
@@ -32,6 +32,9 @@ yarn add @pika/plugin-bundle-types --dev
 
 For more information about @pika/pack & help getting started, [check out the main project repo](https://github.com/pikapkg/pack).
 
+## Options
+
+- `"tsconfig"`: The relative path to the `tsconfig.json` config file to use. Defaults to the top-level project TypeScript config file, if one exists.
 
 ## Result
 

--- a/packages/plugin-bundle-types/README.md
+++ b/packages/plugin-bundle-types/README.md
@@ -35,7 +35,7 @@ For more information about @pika/pack & help getting started, [check out the mai
 ## Options
 
 - `"tsconfig"`: The relative path to the `tsconfig.json` config file to use. Defaults to the top-level project TypeScript config file, if one exists.
-- `"entrypoint"` (Default: `"types"`): Customize the package.json manifest entrypoint set by this plugin. Accepts either a string or an array of strings. Changing this is not recommended for most usage.
+- `"entrypoint"` (Default: `"types"`): Customize the package.json manifest entrypoint set by this plugin. Accepts either a string, an array of strings, or `null` to disable entrypoint. Changing this is not recommended for most usage.
 
 ## Result
 

--- a/packages/plugin-bundle-types/src/index.ts
+++ b/packages/plugin-bundle-types/src/index.ts
@@ -231,12 +231,14 @@ export async function beforeJob({out}: BuilderOptions) {
 }
 
 export function manifest(manifest, {options}: BuilderOptions) {
-  let keys = options.entrypoint || [DEFAULT_ENTRYPOINT];
-  if (typeof keys === 'string') {
-    keys = [keys];
-  }
-  for (const key of keys) {
-    manifest[key] = manifest[key] || 'dist-types/index.d.ts';
+  if (options.entrypoint !== null) {
+    let keys = options.entrypoint || [DEFAULT_ENTRYPOINT];
+    if (typeof keys === 'string') {
+      keys = [keys];
+    }
+    for (const key of keys) {
+      manifest[key] = manifest[key] || 'dist-types/index.d.ts';
+    }
   }
 }
 

--- a/packages/plugin-bundle-types/src/index.ts
+++ b/packages/plugin-bundle-types/src/index.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import rimraf from 'rimraf';
 import {BuilderOptions, MessageError} from '@pika/types';
 import {Extractor, ExtractorConfig, ExtractorResult, IConfigFile} from '@microsoft/api-extractor';
+const DEFAULT_ENTRYPOINT = 'types';
 
 /**
  * Config file for API Extractor.  For more info, please visit: https://api-extractor.com
@@ -229,9 +230,14 @@ export async function beforeJob({out}: BuilderOptions) {
   }
 }
 
-export function manifest(newManifest) {
-  newManifest.types = 'dist-types/index.d.ts';
-  return newManifest;
+export function manifest(manifest, {options}: BuilderOptions) {
+  let keys = options.entrypoint || [DEFAULT_ENTRYPOINT];
+  if (typeof keys === 'string') {
+    keys = [keys];
+  }
+  for (const key of keys) {
+    manifest[key] = manifest[key] || 'dist-types/index.d.ts';
+  }
 }
 
 export async function build({cwd, out, options, reporter, manifest}: BuilderOptions): Promise<void> {

--- a/packages/plugin-bundle-web/README.md
+++ b/packages/plugin-bundle-web/README.md
@@ -40,8 +40,8 @@ For more information about @pika/pack & help getting started, [check out the mai
 - `"minify"` (Default: `true`): Specify if bundle should be minifed using [`terser`](https://github.com/terser-js/terser) or not. Can also be [`terser` options object](https://github.com/terser-js/terser#minify-options) to further tweak minification.
 - `"targets"` (Default: `{"esmodules": true}`): The browsers supported/targeted by the build. Defaults to support all browsers that support ES Module (ESM) syntax.
 - `"entrypoint"`: Add a package.json entrypoint for the bundled build. perfect for pointing [UNPKG](https://unpkg.com/) and other CDNs to this build. 
-  - `{"entrypoint: "unpkg"}` will create an "unpkg" entrypoint that points to "dist-web/index.bundled.js".
-  - `{"entrypoint: ["unpkg", "jsdeliver"]}` will create both "unpkg" & "jsdeliver" "dist-web/index.bundled.js" entrypoints.
+  - `{"entrypoint": "unpkg"}` will create an "unpkg" entrypoint that points to "dist-web/index.bundled.js".
+  - `{"entrypoint": ["unpkg", "jsdeliver"]}` will create both "unpkg" & "jsdeliver" "dist-web/index.bundled.js" entrypoints.
 
 ## Result
 

--- a/packages/plugin-bundle-web/README.md
+++ b/packages/plugin-bundle-web/README.md
@@ -39,7 +39,7 @@ For more information about @pika/pack & help getting started, [check out the mai
 - `"namedExports"` (Default: `undefined`): Ecplicitly specify unresolvable named exports (See [`rollup-plugin-commonjs`](https://github.com/rollup/rollup-plugin-commonjs/tree/v9.2.0#custom-named-exports) for more information).
 - `"minify"` (Default: `true`): Specify if bundle should be minifed using [`terser`](https://github.com/terser-js/terser) or not. Can also be [`terser` options object](https://github.com/terser-js/terser#minify-options) to further tweak minification.
 - `"targets"` (Default: `{"esmodules": true}`): The browsers supported/targeted by the build. Defaults to support all browsers that support ES Module (ESM) syntax.
-- `"entrypoint"` (Default: `"browser"`): Customize the package.json manifest entrypoint set by this plugin. Accepts either a string or an array of strings. Changing this is not recommended for most usage.
+- `"entrypoint"` (Default: `"browser"`): Customize the package.json manifest entrypoint set by this plugin. Accepts either a string, an array of strings, or `null` to disable entrypoint. Changing this is not recommended for most usage.
   - `{"entrypoint": "browser"}` will create an "browser" entrypoint that points to "dist-web/index.bundled.js". This is supported by both [`unpkg`](https://unpkg.com) and [`jsdelivr`](https://jsdelivr.com).
   - `{"entrypoint": ["unpkg", "jsdelivr"]}` will create both "unpkg" & "jsdelivr" "dist-web/index.bundled.js" entrypoints.
 

--- a/packages/plugin-bundle-web/README.md
+++ b/packages/plugin-bundle-web/README.md
@@ -39,7 +39,7 @@ For more information about @pika/pack & help getting started, [check out the mai
 - `"namedExports"` (Default: `undefined`): Ecplicitly specify unresolvable named exports (See [`rollup-plugin-commonjs`](https://github.com/rollup/rollup-plugin-commonjs/tree/v9.2.0#custom-named-exports) for more information).
 - `"minify"` (Default: `true`): Specify if bundle should be minifed using [`terser`](https://github.com/terser-js/terser) or not. Can also be [`terser` options object](https://github.com/terser-js/terser#minify-options) to further tweak minification.
 - `"targets"` (Default: `{"esmodules": true}`): The browsers supported/targeted by the build. Defaults to support all browsers that support ES Module (ESM) syntax.
-- `"entrypoint"`: Add a package.json entrypoint for the bundled build. perfect for pointing [UNPKG](https://unpkg.com/) and other CDNs to this build. 
+- `"entrypoint"` (Default: `"browser"`): Customize the package.json manifest entrypoint set by this plugin. Accepts either a string or an array of strings. Changing this is not recommended for most usage.
   - `{"entrypoint": "browser"}` will create an "browser" entrypoint that points to "dist-web/index.bundled.js". This is supported by both [`unpkg`](https://unpkg.com) and [`jsdelivr`](https://jsdelivr.com).
   - `{"entrypoint": ["unpkg", "jsdelivr"]}` will create both "unpkg" & "jsdelivr" "dist-web/index.bundled.js" entrypoints.
 

--- a/packages/plugin-bundle-web/README.md
+++ b/packages/plugin-bundle-web/README.md
@@ -41,7 +41,7 @@ For more information about @pika/pack & help getting started, [check out the mai
 - `"targets"` (Default: `{"esmodules": true}`): The browsers supported/targeted by the build. Defaults to support all browsers that support ES Module (ESM) syntax.
 - `"entrypoint"`: Add a package.json entrypoint for the bundled build. perfect for pointing [UNPKG](https://unpkg.com/) and other CDNs to this build. 
   - `{"entrypoint": "unpkg"}` will create an "unpkg" entrypoint that points to "dist-web/index.bundled.js".
-  - `{"entrypoint": ["unpkg", "jsdeliver"]}` will create both "unpkg" & "jsdeliver" "dist-web/index.bundled.js" entrypoints.
+  - `{"entrypoint": ["unpkg", "jsdelivr"]}` will create both "unpkg" & "jsdelivr" "dist-web/index.bundled.js" entrypoints.
 
 ## Result
 

--- a/packages/plugin-bundle-web/README.md
+++ b/packages/plugin-bundle-web/README.md
@@ -40,7 +40,7 @@ For more information about @pika/pack & help getting started, [check out the mai
 - `"minify"` (Default: `true`): Specify if bundle should be minifed using [`terser`](https://github.com/terser-js/terser) or not. Can also be [`terser` options object](https://github.com/terser-js/terser#minify-options) to further tweak minification.
 - `"targets"` (Default: `{"esmodules": true}`): The browsers supported/targeted by the build. Defaults to support all browsers that support ES Module (ESM) syntax.
 - `"entrypoint"`: Add a package.json entrypoint for the bundled build. perfect for pointing [UNPKG](https://unpkg.com/) and other CDNs to this build. 
-  - `{"entrypoint": "unpkg"}` will create an "unpkg" entrypoint that points to "dist-web/index.bundled.js".
+  - `{"entrypoint": "browser"}` will create an "browser" entrypoint that points to "dist-web/index.bundled.js". This is supported by both [`unpkg`](https://unpkg.com) and [`jsdelivr`](https://jsdelivr.com).
   - `{"entrypoint": ["unpkg", "jsdelivr"]}` will create both "unpkg" & "jsdelivr" "dist-web/index.bundled.js" entrypoints.
 
 ## Result

--- a/packages/plugin-bundle-web/src/index.ts
+++ b/packages/plugin-bundle-web/src/index.ts
@@ -28,13 +28,12 @@ export async function beforeJob({out}: BuilderOptions) {
 }
 
 export function manifest(manifest, {options}: BuilderOptions) {
-  const entrypoint = options.entrypoint || DEFAULT_ENTRYPOINT;
-  if (entrypoint instanceof Array) {
-    entrypoint.forEach(e => {
-      manifest[e] = 'dist-web/index.bundled.js';
-    });
-  } else {
-    manifest[entrypoint] = 'dist-web/index.bundled.js';
+  let keys = options.entrypoint || [DEFAULT_ENTRYPOINT];
+  if (typeof keys === 'string') {
+    keys = [keys];
+  }
+  for (const key of keys) {
+    manifest[key] = manifest[key] || 'dist-web/index.bundled.js';
   }
 }
 

--- a/packages/plugin-bundle-web/src/index.ts
+++ b/packages/plugin-bundle-web/src/index.ts
@@ -28,12 +28,14 @@ export async function beforeJob({out}: BuilderOptions) {
 }
 
 export function manifest(manifest, {options}: BuilderOptions) {
-  let keys = options.entrypoint || [DEFAULT_ENTRYPOINT];
-  if (typeof keys === 'string') {
-    keys = [keys];
-  }
-  for (const key of keys) {
-    manifest[key] = manifest[key] || 'dist-web/index.bundled.js';
+  if(options.entrypoint !== null) {
+    let keys = options.entrypoint || [DEFAULT_ENTRYPOINT];
+    if (typeof keys === 'string') {
+      keys = [keys];
+    }
+    for (const key of keys) {
+      manifest[key] = manifest[key] || 'dist-web/index.bundled.js';
+    }
   }
 }
 

--- a/packages/plugin-bundle-web/src/index.ts
+++ b/packages/plugin-bundle-web/src/index.ts
@@ -12,6 +12,8 @@ import fs from 'fs';
 import {BuilderOptions, MessageError} from '@pika/types';
 import {rollup} from 'rollup';
 
+const DEFAULT_ENTRYPOINT = 'browser';
+
 export async function beforeJob({out}: BuilderOptions) {
   const srcDirectory = path.join(out, 'dist-web/');
   if (!fs.existsSync(srcDirectory)) {
@@ -26,14 +28,13 @@ export async function beforeJob({out}: BuilderOptions) {
 }
 
 export function manifest(manifest, {options}: BuilderOptions) {
-  if (options.entrypoint) {
-    if (options.entrypoint instanceof Array) {
-      options.entrypoint.forEach(entrypoint => {
-        manifest[entrypoint] = 'dist-web/index.bundled.js';
-      });
-    } else {
-      manifest[options.entrypoint] = 'dist-web/index.bundled.js';
-    }
+  const entrypoint = options.entrypoint || DEFAULT_ENTRYPOINT;
+  if (entrypoint instanceof Array) {
+    entrypoint.forEach(e => {
+      manifest[e] = 'dist-web/index.bundled.js';
+    });
+  } else {
+    manifest[entrypoint] = 'dist-web/index.bundled.js';
   }
 }
 


### PR DESCRIPTION
* [`@pika/plugin-bundle-web`] Started by just fixing some errors in the documentation, as well as add a more sensible recommendation (0f09d63, 2ca6197, e24c129)
* [`@pika/plugin-bundle-web`] Then felt like making `browser` the default entrypoint would make sense as it supports the most common CDNs ([unpkg.com ](https://unpkg.com) and [jsdelivr.com](https://jsdelivr.com)) and most other builders have default entrypoints as of [v0.7.0](https://github.com/pikapkg/builders/releases/v0.7.0) (c23a407)

Then I felt like there should be a way to not get the entrypoint if you for some reason want to replicate old behaviour. Seems like this would make sense to do to all builders and not only to `@pika/plugin-bundle-web`.

* [`@pika/plugin-bundle-types`] Add entrypoint option to builder that misses it, as well as document some undocument options. (84aa6ca, 48fb320)
* [`@pika/plugin-bundle-web`] Use consistent codepath and documentation for bundle-web too (8639f19)
* Add possibility to set `entrypoint: null` to disable default entrypoint in all builders that uses `options.entrypoint`) (4374374)