### PR TITLE
[@pika/plugin-build-web] Fix incorrect default entrypoint

### DIFF
--- a/packages/plugin-build-web/src/index.ts
+++ b/packages/plugin-build-web/src/index.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import fs from 'fs';
 import {BuilderOptions, MessageError} from '@pika/types';
 import {rollup} from 'rollup';
-const DEFAULT_ENTRYPOINT = 'deno';
+const DEFAULT_ENTRYPOINT = 'module';
 export async function beforeJob({out}: BuilderOptions) {
   const srcDirectory = path.join(out, 'dist-src/');
   if (!fs.existsSync(srcDirectory)) {


### PR DESCRIPTION
After https://github.com/pikapkg/builders/releases/v0.7.0 (ac46b76fd5775fddefd180ca515fe7dc46d03b4f), the entrypoint that `@pika/plugin-build-web` produces is incorrect. This fixes this.

The workaround for `@pika/plugin-build-web@0.7.0` is to set 
```
[
    "@pika/plugin-build-web",
    {
        "entrypoint": "module"
    }
]
```