### PR TITLE
Replace @microsoft/api-extractor with rollup-plugin-dts

### DIFF
--- a/packages/plugin-build-node/package-lock.json
+++ b/packages/plugin-build-node/package-lock.json
@@ -1445,9 +1445,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.3.312",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.312.tgz",
-			"integrity": "sha512-/Nk6Hvwt+RfS9X3oA4IXpWqpcnS7cdWsTMP4AmrP8hPpxtZbHemvTEYzjAKghk28aS9zIV8NwGHNt8H+6OmJug=="
+			"version": "1.3.313",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.313.tgz",
+			"integrity": "sha512-rWbB6P3kPpWez/BZqrVatQ+lxJaDTv9pWgUUGYAA0/O5+YZLm6RiGy2Roml6rQj4EJ4r/eTdO0ppOZUUP2oFpQ=="
 		},
 		"elegant-spinner": {
 			"version": "1.0.1",

--- a/packages/plugin-build-umd/package-lock.json
+++ b/packages/plugin-build-umd/package-lock.json
@@ -1438,9 +1438,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.3.312",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.312.tgz",
-			"integrity": "sha512-/Nk6Hvwt+RfS9X3oA4IXpWqpcnS7cdWsTMP4AmrP8hPpxtZbHemvTEYzjAKghk28aS9zIV8NwGHNt8H+6OmJug=="
+			"version": "1.3.313",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.313.tgz",
+			"integrity": "sha512-rWbB6P3kPpWez/BZqrVatQ+lxJaDTv9pWgUUGYAA0/O5+YZLm6RiGy2Roml6rQj4EJ4r/eTdO0ppOZUUP2oFpQ=="
 		},
 		"elegant-spinner": {
 			"version": "1.0.1",

--- a/packages/plugin-bundle-node/package-lock.json
+++ b/packages/plugin-bundle-node/package-lock.json
@@ -1460,9 +1460,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.3.312",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.312.tgz",
-			"integrity": "sha512-/Nk6Hvwt+RfS9X3oA4IXpWqpcnS7cdWsTMP4AmrP8hPpxtZbHemvTEYzjAKghk28aS9zIV8NwGHNt8H+6OmJug=="
+			"version": "1.3.313",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.313.tgz",
+			"integrity": "sha512-rWbB6P3kPpWez/BZqrVatQ+lxJaDTv9pWgUUGYAA0/O5+YZLm6RiGy2Roml6rQj4EJ4r/eTdO0ppOZUUP2oFpQ=="
 		},
 		"elegant-spinner": {
 			"version": "1.0.1",

--- a/packages/plugin-bundle-types/package-lock.json
+++ b/packages/plugin-bundle-types/package-lock.json
@@ -8,7 +8,6 @@
 			"version": "7.5.5",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
 			"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
-			"dev": true,
 			"requires": {
 				"@babel/highlight": "^7.0.0"
 			}
@@ -17,73 +16,11 @@
 			"version": "7.5.0",
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
 			"integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
-			"dev": true,
 			"requires": {
 				"chalk": "^2.0.0",
 				"esutils": "^2.0.2",
 				"js-tokens": "^4.0.0"
 			}
-		},
-		"@microsoft/api-extractor": {
-			"version": "7.6.2",
-			"resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.6.2.tgz",
-			"integrity": "sha512-4nK2uAWwC1nfzpEbyCwPfe/39aHkoWIhsodj8yrWTxMpH0eI7Ik/SdHtn3bDKVHIK67EnaR5//fnevpj9ACByw==",
-			"requires": {
-				"@microsoft/api-extractor-model": "7.6.0",
-				"@microsoft/node-core-library": "3.18.0",
-				"@microsoft/ts-command-line": "4.3.5",
-				"@microsoft/tsdoc": "0.12.14",
-				"colors": "~1.2.1",
-				"lodash": "~4.17.15",
-				"resolve": "1.8.1",
-				"source-map": "~0.6.1",
-				"typescript": "~3.7.2"
-			}
-		},
-		"@microsoft/api-extractor-model": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.6.0.tgz",
-			"integrity": "sha512-7gtxCxUMLDv3k1NE7MCaUaQeAwH5dEt/vjnq22cOUiCfiYOxdrvolab+WIXSNKV6rhe+AnIovR9tkxtxw5OiYA==",
-			"requires": {
-				"@microsoft/node-core-library": "3.18.0",
-				"@microsoft/tsdoc": "0.12.14"
-			}
-		},
-		"@microsoft/node-core-library": {
-			"version": "3.18.0",
-			"resolved": "https://registry.npmjs.org/@microsoft/node-core-library/-/node-core-library-3.18.0.tgz",
-			"integrity": "sha512-VzzSHtcwgHVW1xbHqpngfn+OS1trAZ1Tw3XXBlMsEKe7Wz7FF2gLr0hZa6x9Pemk5pkd4tu4+GTSOJjCKGjrgg==",
-			"requires": {
-				"@types/node": "8.10.54",
-				"colors": "~1.2.1",
-				"fs-extra": "~7.0.1",
-				"jju": "~1.4.0",
-				"semver": "~5.3.0",
-				"timsort": "~0.3.0",
-				"z-schema": "~3.18.3"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "8.10.54",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.54.tgz",
-					"integrity": "sha512-kaYyLYf6ICn6/isAyD4K1MyWWd5Q3JgH6bnMN089LUx88+s4W8GvK9Q6JMBVu5vsFFp7pMdSxdKmlBXwH/VFRg=="
-				}
-			}
-		},
-		"@microsoft/ts-command-line": {
-			"version": "4.3.5",
-			"resolved": "https://registry.npmjs.org/@microsoft/ts-command-line/-/ts-command-line-4.3.5.tgz",
-			"integrity": "sha512-CN3j86apNOmllUmeJ0AyRfTYA2BP2xlnfgmnyp1HWLqcJmR/zLe/fk/+gohGnNt7o5/qHta3681LQhO2Yy3GFw==",
-			"requires": {
-				"@types/argparse": "1.0.33",
-				"argparse": "~1.0.9",
-				"colors": "~1.2.1"
-			}
-		},
-		"@microsoft/tsdoc": {
-			"version": "0.12.14",
-			"resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.12.14.tgz",
-			"integrity": "sha512-518yewjSga1jLdiLrcmpMFlaba5P+50b0TWNFUpC+SL9Yzf0kMi57qw+bMl+rQ08cGqH1vLx4eg9YFUbZXgZ0Q=="
 		},
 		"@pika/cli": {
 			"version": "0.2.0",
@@ -122,6 +59,17 @@
 				"strip-bom": "^4.0.0",
 				"validate-npm-package-license": "^3.0.4",
 				"yargs-parser": "^13.1.1"
+			},
+			"dependencies": {
+				"rimraf": {
+					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				}
 			}
 		},
 		"@pika/types": {
@@ -162,10 +110,10 @@
 				"defer-to-connect": "^1.0.1"
 			}
 		},
-		"@types/argparse": {
-			"version": "1.0.33",
-			"resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.33.tgz",
-			"integrity": "sha512-VQgHxyPMTj3hIlq9SY1mctqx+Jj8kpQfoLvDlVSDNOyuYs8JYfkuY3OW/4+dO657yPmNhHpePRx0/Tje5ImNVQ=="
+		"@types/estree": {
+			"version": "0.0.39",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
 		},
 		"@types/events": {
 			"version": "3.0.0",
@@ -201,6 +149,11 @@
 			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
 			"integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
 			"dev": true
+		},
+		"acorn": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+			"integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ=="
 		},
 		"ansi-align": {
 			"version": "3.0.0",
@@ -255,7 +208,6 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
 			"requires": {
 				"color-convert": "^1.9.0"
 			}
@@ -270,6 +222,7 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
 			"requires": {
 				"sprintf-js": "~1.0.2"
 			}
@@ -456,7 +409,6 @@
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dev": true,
 			"requires": {
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
@@ -562,7 +514,6 @@
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
 			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
 			"requires": {
 				"color-name": "1.1.3"
 			}
@@ -570,18 +521,13 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-			"dev": true
-		},
-		"colors": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/colors/-/colors-1.2.5.tgz",
-			"integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg=="
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
 		"commander": {
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"dev": true
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -704,6 +650,17 @@
 				"p-map": "^2.0.0",
 				"pify": "^4.0.1",
 				"rimraf": "^2.6.3"
+			},
+			"dependencies": {
+				"rimraf": {
+					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				}
 			}
 		},
 		"detect-indent": {
@@ -760,8 +717,7 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"esprima": {
 			"version": "4.0.1",
@@ -772,8 +728,7 @@
 		"esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-			"dev": true
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
 		},
 		"execa": {
 			"version": "2.1.0",
@@ -825,16 +780,6 @@
 			"dev": true,
 			"requires": {
 				"locate-path": "^2.0.0"
-			}
-		},
-		"fs-extra": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-			"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-			"requires": {
-				"graceful-fs": "^4.1.2",
-				"jsonfile": "^4.0.0",
-				"universalify": "^0.1.0"
 			}
 		},
 		"fs.realpath": {
@@ -933,7 +878,8 @@
 		"graceful-fs": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-			"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
+			"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+			"dev": true
 		},
 		"has-ansi": {
 			"version": "2.0.0",
@@ -955,8 +901,7 @@
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-			"dev": true
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 		},
 		"has-yarn": {
 			"version": "2.1.0",
@@ -1248,16 +1193,10 @@
 			"integrity": "sha512-flaQ/45dMqCYSMzBQI/h3bcto6T70uN7kjNnI8n3gQU6no5p+QcnMWBNXkraED0YvbUymxKaqdvgPa09RZQM5A==",
 			"dev": true
 		},
-		"jju": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
-			"integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo="
-		},
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-			"dev": true
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
 		"js-yaml": {
 			"version": "3.13.1",
@@ -1280,14 +1219,6 @@
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
 			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
 			"dev": true
-		},
-		"jsonfile": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-			"requires": {
-				"graceful-fs": "^4.1.6"
-			}
 		},
 		"keyv": {
 			"version": "3.1.0",
@@ -1670,17 +1601,8 @@
 		"lodash": {
 			"version": "4.17.15",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-		},
-		"lodash.get": {
-			"version": "4.4.2",
-			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
-		},
-		"lodash.isequal": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+			"dev": true
 		},
 		"lodash.zip": {
 			"version": "4.2.0",
@@ -1956,14 +1878,11 @@
 					"integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
 					"dev": true
 				},
-				"resolve": {
-					"version": "1.12.2",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.2.tgz",
-					"integrity": "sha512-cAVTI2VLHWYsGOirfeYVVQ7ZDejtQ9fp4YhYckWDEkFfqbVjaT11iM8k6xSAfGFMM+gDpZjMnFssPu8we+mqFw==",
-					"dev": true,
-					"requires": {
-						"path-parse": "^1.0.6"
-					}
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"dev": true
 				}
 			}
 		},
@@ -2018,12 +1937,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
 					"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-					"dev": true
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 					"dev": true
 				}
 			}
@@ -2204,14 +2117,6 @@
 				"registry-auth-token": "^4.0.0",
 				"registry-url": "^5.0.0",
 				"semver": "^6.2.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
-				}
 			}
 		},
 		"parse-json": {
@@ -2250,7 +2155,8 @@
 		"path-parse": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"dev": true
 		},
 		"path-type": {
 			"version": "3.0.0",
@@ -2539,11 +2445,12 @@
 			}
 		},
 		"resolve": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-			"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.2.tgz",
+			"integrity": "sha512-cAVTI2VLHWYsGOirfeYVVQ7ZDejtQ9fp4YhYckWDEkFfqbVjaT11iM8k6xSAfGFMM+gDpZjMnFssPu8we+mqFw==",
+			"dev": true,
 			"requires": {
-				"path-parse": "^1.0.5"
+				"path-parse": "^1.0.6"
 			}
 		},
 		"resolve-from": {
@@ -2572,11 +2479,36 @@
 			}
 		},
 		"rimraf": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.0.tgz",
+			"integrity": "sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==",
 			"requires": {
 				"glob": "^7.1.3"
+			}
+		},
+		"rollup": {
+			"version": "1.27.4",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-1.27.4.tgz",
+			"integrity": "sha512-UaGNOIax/Ixfd92CAAanUilx2RSkkwEfC1lCTw1eL5Re6NURWgX66ARZt5+3px4kYnpSwzyOot4r18c2b+QgJQ==",
+			"requires": {
+				"@types/estree": "*",
+				"@types/node": "*",
+				"acorn": "^7.1.0"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "12.12.12",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.12.tgz",
+					"integrity": "sha512-MGuvYJrPU0HUwqF7LqvIj50RZUX23Z+m583KBygKYUZLlZ88n6w28XRNJRJgsHukLEnLz6w6SvxZoLgbr5wLqQ=="
+				}
+			}
+		},
+		"rollup-plugin-dts": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-1.1.12.tgz",
+			"integrity": "sha512-f+maIUbEZpqZp5BWJcyYxzpOjLGEJp9XziBiOaRapbanbucYhJimXaviXwSInf+8oAFwZk4FGH2zgZO+TqVG0g==",
+			"requires": {
+				"@babel/code-frame": "^7.5.5"
 			}
 		},
 		"run-async": {
@@ -2631,9 +2563,10 @@
 			"dev": true
 		},
 		"semver": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-			"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"dev": true
 		},
 		"semver-diff": {
 			"version": "2.1.0",
@@ -2642,6 +2575,14 @@
 			"dev": true,
 			"requires": {
 				"semver": "^5.0.3"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"dev": true
+				}
 			}
 		},
 		"shebang-command": {
@@ -2670,11 +2611,6 @@
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
 			"integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
 			"dev": true
-		},
-		"source-map": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 		},
 		"spdx-correct": {
 			"version": "3.1.0",
@@ -2720,7 +2656,8 @@
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
 		},
 		"string-width": {
 			"version": "4.2.0",
@@ -2795,7 +2732,6 @@
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"dev": true,
 			"requires": {
 				"has-flag": "^3.0.0"
 			}
@@ -2959,11 +2895,6 @@
 			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
 			"dev": true
 		},
-		"timsort": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
-			"integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
-		},
 		"tlds": {
 			"version": "1.203.1",
 			"resolved": "https://registry.npmjs.org/tlds/-/tlds-1.203.1.tgz",
@@ -3006,7 +2937,8 @@
 		"typescript": {
 			"version": "3.7.2",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
-			"integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ=="
+			"integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==",
+			"dev": true
 		},
 		"unique-string": {
 			"version": "1.0.0",
@@ -3016,11 +2948,6 @@
 			"requires": {
 				"crypto-random-string": "^1.0.0"
 			}
-		},
-		"universalify": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
 		},
 		"update-notifier": {
 			"version": "3.0.1",
@@ -3109,11 +3036,6 @@
 			"requires": {
 				"builtins": "^1.0.3"
 			}
-		},
-		"validator": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/validator/-/validator-8.2.0.tgz",
-			"integrity": "sha512-Yw5wW34fSv5spzTXNkokD6S6/Oq92d8q/t14TqsS3fAiA1RYnxSFSIZ+CY3n6PGGRCq5HhJTSepQvFUS2QUDxA=="
 		},
 		"which": {
 			"version": "2.0.2",
@@ -3245,17 +3167,6 @@
 			"requires": {
 				"camelcase": "^5.0.0",
 				"decamelize": "^1.2.0"
-			}
-		},
-		"z-schema": {
-			"version": "3.18.4",
-			"resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.18.4.tgz",
-			"integrity": "sha512-DUOKC/IhbkdLKKiV89gw9DUauTV8U/8yJl1sjf6MtDmzevLKOF2duNJ495S3MFVjqZarr+qNGCPbkg4mu4PpLw==",
-			"requires": {
-				"commander": "^2.7.1",
-				"lodash.get": "^4.0.0",
-				"lodash.isequal": "^4.0.0",
-				"validator": "^8.0.0"
 			}
 		}
 	}

--- a/packages/plugin-bundle-types/package.json
+++ b/packages/plugin-bundle-types/package.json
@@ -26,9 +26,10 @@
     "build": "pika-pack build"
   },
   "dependencies": {
-    "@microsoft/api-extractor": "^7.1.5",
     "@pika/types": "^0.7.1",
-    "rimraf": "^2.6.3"
+    "rollup": "^1.1.0",
+    "rimraf": "^3.0.0",
+    "rollup-plugin-dts": "^1.1.12"
   },
   "devDependencies": {
     "@pika/pack": "^0.5.0",

--- a/packages/plugin-bundle-types/pkg/dist-node/index.js
+++ b/packages/plugin-bundle-types/pkg/dist-node/index.js
@@ -8,150 +8,10 @@ var path = _interopDefault(require('path'));
 var fs = _interopDefault(require('fs'));
 var rimraf = _interopDefault(require('rimraf'));
 var types = require('@pika/types');
-var apiExtractor = require('@microsoft/api-extractor');
+var rollup = require('rollup');
+var rollupPluginDts = _interopDefault(require('rollup-plugin-dts'));
 
 const DEFAULT_ENTRYPOINT = 'types';
-/**
- * Config file for API Extractor.  For more info, please visit: https://api-extractor.com
- */
-
-function getConfigData(cwd, out, tsConfigPath) {
-  return {
-    $schema: 'https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json',
-
-    /**
-     * Optionally specifies another JSON config file that this file extends from.  This provides a way for
-     * standard settings to be shared across multiple projects.
-     *
-     * If the path starts with "./" or "../", the path is resolved relative to the folder of the file that contains
-     * the "extends" field.  Otherwise, the first path segment is interpreted as an NPM package name, and will be
-     * resolved using NodeJS require().
-     *
-     * SUPPORTED TOKENS: none
-     * DEFAULT VALUE: ""
-     */
-    // "extends": "./shared/api-extractor-base.json"
-    // "extends": "my-package/include/api-extractor-base.json"
-
-    /**
-     * Determines the "<projectFolder>" token that can be used with other config file settings.  The project folder
-     * typically contains the tsconfig.json and package.json config files, but the path is user-defined.
-     *
-     * The path is resolved relative to the folder of the config file that contains the setting.
-     *
-     * The default value for "projectFolder" is the token "<lookup>", which means the folder is determined by traversing
-     * parent folders, starting from the folder containing api-extractor.json, and stopping at the first folder
-     * that contains a tsconfig.json file.  If a tsconfig.json file cannot be found in this way, then an error
-     * will be reported.
-     *
-     * SUPPORTED TOKENS: <lookup>
-     * DEFAULT VALUE: "<lookup>"
-     */
-    projectFolder: cwd,
-
-    /**
-     * (REQUIRED) Specifies the .d.ts file to be used as the starting point for analysis.  API Extractor
-     * analyzes the symbols exported by this module.
-     *
-     * The file extension must be ".d.ts" and not ".ts".
-     *
-     * The path is resolved relative to the folder of the config file that contains the setting; to change this,
-     * prepend a folder token such as "<projectFolder>".
-     *
-     * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
-     */
-    mainEntryPointFilePath: `${out}/dist-types/index.d.ts`,
-
-    /**
-     * Determines how the TypeScript compiler engine will be invoked by API Extractor.
-     */
-    compiler: {
-      tsconfigFilePath: tsConfigPath
-    },
-
-    /**
-     * Configures how the API report file (*.api.md) will be generated.
-     */
-    apiReport: {
-      enabled: false,
-      reportFileName: 'report.api.md'
-    },
-    docModel: {
-      enabled: false
-    },
-    tsdocMetadata: {
-      enabled: false
-    },
-    dtsRollup: {
-      enabled: true,
-
-      /**
-       * Specifies the output path for a .d.ts rollup file to be generated without any trimming.
-       * This file will include all declarations that are exported by the main entry point.
-       *
-       * If the path is an empty string, then this file will not be written.
-       *
-       * The path is resolved relative to the folder of the config file that contains the setting; to change this,
-       * prepend a folder token such as "<projectFolder>".
-       *
-       * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
-       * DEFAULT VALUE: "<projectFolder>/dist/<unscopedPackageName>.d.ts"
-       */
-      untrimmedFilePath: `${out}/dist-types-bundled/index.d.ts`
-    },
-
-    /**
-     * Configures how API Extractor reports error and warning messages produced during analysis.
-     *
-     * There are three sources of messages:  compiler messages, API Extractor messages, and TSDoc messages.
-     */
-    messages: {
-      /**
-       * Configures handling of diagnostic messages reported by the TypeScript compiler engine while analyzing
-       * the input .d.ts files.
-       *
-       * TypeScript message identifiers start with "TS" followed by an integer.  For example: "TS2551"
-       *
-       * DEFAULT VALUE:  A single "default" entry with logLevel=warning.
-       */
-      compilerMessageReporting: {
-        /**
-         * Configures the default routing for messages that don't match an explicit rule in this table.
-         */
-        default: {
-          /**
-           * Specifies whether the message should be written to the the tool's output log.  Note that
-           * the "addToApiReportFile" property may supersede this option.
-           *
-           * Possible values: "error", "warning", "none"
-           *
-           * Errors cause the build to fail and return a nonzero exit code.  Warnings cause a production build fail
-           * and return a nonzero exit code.  For a non-production build (e.g. when "api-extractor run" includes
-           * the "--local" option), the warning is displayed but the build will not fail.
-           *
-           * DEFAULT VALUE: "warning"
-           */
-          logLevel: 'error'
-        }
-      }
-    }
-  };
-}
-
-function getTsConfigPath(options, cwd) {
-  return path.resolve(cwd, options.tsconfig || 'tsconfig.json');
-}
-
-async function beforeBuild({
-  cwd,
-  options
-}) {
-  const tsConfigPath = getTsConfigPath(options, cwd);
-
-  if (!fs.existsSync(tsConfigPath)) {
-    throw new types.MessageError('"tsconfig.json" manifest not found.');
-  }
-}
 async function beforeJob({
   out
 }) {
@@ -178,42 +38,30 @@ function manifest(manifest, {
     }
 
     for (const key of keys) {
-      manifest[key] = manifest[key] || 'dist-types/index.d.ts';
+      manifest[key] = 'dist-types/index.d.ts';
     }
   }
 }
 async function build({
-  cwd,
   out,
   options,
-  reporter,
-  manifest
+  reporter
 }) {
-  const typesBundledLoc = path.join(out, 'dist-types-bundled/');
-  const typesLoc = path.join(out, 'dist-types/'); // Load and parse the api-extractor.json file
-
-  const extractorConfig = apiExtractor.ExtractorConfig.prepare({
-    configObject: getConfigData(cwd, out, getTsConfigPath(options, cwd)),
-    configObjectFullPath: undefined,
-    packageJson: manifest,
-    packageJsonFullPath: path.join(cwd, 'package.json')
+  const readFromTypes = path.join(out, 'dist-types', 'index.d.ts');
+  const writeToTypes = path.join(out, 'dist-types');
+  const writeToTypesBundled = path.join(writeToTypes, 'index.d.ts');
+  const result = await rollup.rollup({
+    input: readFromTypes,
+    plugins: [rollupPluginDts()]
   });
-  extractorConfig.packageJson = manifest; // Invoke API Extractor to generate a bundled index.d.ts from the dist-types-unbundled/ dir.
-
-  const extractorResult = apiExtractor.Extractor.invoke(extractorConfig, {
-    localBuild: false
-  }); // Handle a failure
-
-  if (!extractorResult.succeeded) {
-    throw new types.MessageError(`Unable to bundle types. ${extractorResult.errorCount} errors` + ` and ${extractorResult.warningCount} warnings encountered.`);
-  }
-
-  rimraf.sync(typesLoc);
-  fs.renameSync(typesBundledLoc, typesLoc);
-  reporter.created(path.join(out, 'dist-types', 'index.d.ts'), 'types, bundled');
+  rimraf.sync(writeToTypes);
+  await result.write({
+    file: writeToTypesBundled,
+    format: 'esm'
+  });
+  reporter.created(writeToTypesBundled);
 }
 
-exports.beforeBuild = beforeBuild;
 exports.beforeJob = beforeJob;
 exports.build = build;
 exports.manifest = manifest;

--- a/packages/plugin-bundle-types/pkg/dist-src/index.js
+++ b/packages/plugin-bundle-types/pkg/dist-src/index.js
@@ -2,128 +2,9 @@ import path from 'path';
 import fs from 'fs';
 import rimraf from 'rimraf';
 import { MessageError } from '@pika/types';
-import { Extractor, ExtractorConfig } from '@microsoft/api-extractor';
+import { rollup } from 'rollup';
+import rollupPluginDts from 'rollup-plugin-dts';
 const DEFAULT_ENTRYPOINT = 'types';
-/**
- * Config file for API Extractor.  For more info, please visit: https://api-extractor.com
- */
-function getConfigData(cwd, out, tsConfigPath) {
-    return {
-        $schema: 'https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json',
-        /**
-         * Optionally specifies another JSON config file that this file extends from.  This provides a way for
-         * standard settings to be shared across multiple projects.
-         *
-         * If the path starts with "./" or "../", the path is resolved relative to the folder of the file that contains
-         * the "extends" field.  Otherwise, the first path segment is interpreted as an NPM package name, and will be
-         * resolved using NodeJS require().
-         *
-         * SUPPORTED TOKENS: none
-         * DEFAULT VALUE: ""
-         */
-        // "extends": "./shared/api-extractor-base.json"
-        // "extends": "my-package/include/api-extractor-base.json"
-        /**
-         * Determines the "<projectFolder>" token that can be used with other config file settings.  The project folder
-         * typically contains the tsconfig.json and package.json config files, but the path is user-defined.
-         *
-         * The path is resolved relative to the folder of the config file that contains the setting.
-         *
-         * The default value for "projectFolder" is the token "<lookup>", which means the folder is determined by traversing
-         * parent folders, starting from the folder containing api-extractor.json, and stopping at the first folder
-         * that contains a tsconfig.json file.  If a tsconfig.json file cannot be found in this way, then an error
-         * will be reported.
-         *
-         * SUPPORTED TOKENS: <lookup>
-         * DEFAULT VALUE: "<lookup>"
-         */
-        projectFolder: cwd,
-        /**
-         * (REQUIRED) Specifies the .d.ts file to be used as the starting point for analysis.  API Extractor
-         * analyzes the symbols exported by this module.
-         *
-         * The file extension must be ".d.ts" and not ".ts".
-         *
-         * The path is resolved relative to the folder of the config file that contains the setting; to change this,
-         * prepend a folder token such as "<projectFolder>".
-         *
-         * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
-         */
-        mainEntryPointFilePath: `${out}/dist-types/index.d.ts`,
-        /**
-         * Determines how the TypeScript compiler engine will be invoked by API Extractor.
-         */
-        compiler: {
-            tsconfigFilePath: tsConfigPath,
-        },
-        /**
-         * Configures how the API report file (*.api.md) will be generated.
-         */
-        apiReport: { enabled: false, reportFileName: 'report.api.md' },
-        docModel: { enabled: false },
-        tsdocMetadata: { enabled: false },
-        dtsRollup: {
-            enabled: true,
-            /**
-             * Specifies the output path for a .d.ts rollup file to be generated without any trimming.
-             * This file will include all declarations that are exported by the main entry point.
-             *
-             * If the path is an empty string, then this file will not be written.
-             *
-             * The path is resolved relative to the folder of the config file that contains the setting; to change this,
-             * prepend a folder token such as "<projectFolder>".
-             *
-             * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
-             * DEFAULT VALUE: "<projectFolder>/dist/<unscopedPackageName>.d.ts"
-             */
-            untrimmedFilePath: `${out}/dist-types-bundled/index.d.ts`,
-        },
-        /**
-         * Configures how API Extractor reports error and warning messages produced during analysis.
-         *
-         * There are three sources of messages:  compiler messages, API Extractor messages, and TSDoc messages.
-         */
-        messages: {
-            /**
-             * Configures handling of diagnostic messages reported by the TypeScript compiler engine while analyzing
-             * the input .d.ts files.
-             *
-             * TypeScript message identifiers start with "TS" followed by an integer.  For example: "TS2551"
-             *
-             * DEFAULT VALUE:  A single "default" entry with logLevel=warning.
-             */
-            compilerMessageReporting: {
-                /**
-                 * Configures the default routing for messages that don't match an explicit rule in this table.
-                 */
-                default: {
-                    /**
-                     * Specifies whether the message should be written to the the tool's output log.  Note that
-                     * the "addToApiReportFile" property may supersede this option.
-                     *
-                     * Possible values: "error", "warning", "none"
-                     *
-                     * Errors cause the build to fail and return a nonzero exit code.  Warnings cause a production build fail
-                     * and return a nonzero exit code.  For a non-production build (e.g. when "api-extractor run" includes
-                     * the "--local" option), the warning is displayed but the build will not fail.
-                     *
-                     * DEFAULT VALUE: "warning"
-                     */
-                    logLevel: 'error',
-                },
-            },
-        },
-    };
-}
-function getTsConfigPath(options, cwd) {
-    return path.resolve(cwd, options.tsconfig || 'tsconfig.json');
-}
-export async function beforeBuild({ cwd, options }) {
-    const tsConfigPath = getTsConfigPath(options, cwd);
-    if (!fs.existsSync(tsConfigPath)) {
-        throw new MessageError('"tsconfig.json" manifest not found.');
-    }
-}
 export async function beforeJob({ out }) {
     const typesDir = path.join(out, 'dist-types');
     if (!fs.existsSync(typesDir)) {
@@ -141,29 +22,22 @@ export function manifest(manifest, { options }) {
             keys = [keys];
         }
         for (const key of keys) {
-            manifest[key] = manifest[key] || 'dist-types/index.d.ts';
+            manifest[key] = 'dist-types/index.d.ts';
         }
     }
 }
-export async function build({ cwd, out, options, reporter, manifest }) {
-    const typesBundledLoc = path.join(out, 'dist-types-bundled/');
-    const typesLoc = path.join(out, 'dist-types/');
-    // Load and parse the api-extractor.json file
-    const extractorConfig = ExtractorConfig.prepare({
-        configObject: getConfigData(cwd, out, getTsConfigPath(options, cwd)),
-        configObjectFullPath: undefined,
-        packageJson: manifest,
-        packageJsonFullPath: path.join(cwd, 'package.json'),
+export async function build({ out, options, reporter }) {
+    const readFromTypes = path.join(out, 'dist-types', 'index.d.ts');
+    const writeToTypes = path.join(out, 'dist-types');
+    const writeToTypesBundled = path.join(writeToTypes, 'index.d.ts');
+    const result = await rollup({
+        input: readFromTypes,
+        plugins: [rollupPluginDts()],
     });
-    extractorConfig.packageJson = manifest;
-    // Invoke API Extractor to generate a bundled index.d.ts from the dist-types-unbundled/ dir.
-    const extractorResult = Extractor.invoke(extractorConfig, { localBuild: false });
-    // Handle a failure
-    if (!extractorResult.succeeded) {
-        throw new MessageError(`Unable to bundle types. ${extractorResult.errorCount} errors` +
-            ` and ${extractorResult.warningCount} warnings encountered.`);
-    }
-    rimraf.sync(typesLoc);
-    fs.renameSync(typesBundledLoc, typesLoc);
-    reporter.created(path.join(out, 'dist-types', 'index.d.ts'), 'types, bundled');
+    rimraf.sync(writeToTypes);
+    await result.write({
+        file: writeToTypesBundled,
+        format: 'esm',
+    });
+    reporter.created(writeToTypesBundled);
 }

--- a/packages/plugin-bundle-types/pkg/dist-types/index.d.ts
+++ b/packages/plugin-bundle-types/pkg/dist-types/index.d.ts
@@ -1,5 +1,4 @@
 import { BuilderOptions } from '@pika/types';
-export declare function beforeBuild({ cwd, options }: BuilderOptions): Promise<void>;
 export declare function beforeJob({ out }: BuilderOptions): Promise<void>;
 export declare function manifest(manifest: any, { options }: BuilderOptions): void;
-export declare function build({ cwd, out, options, reporter, manifest }: BuilderOptions): Promise<void>;
+export declare function build({ out, options, reporter }: BuilderOptions): Promise<void>;

--- a/packages/plugin-bundle-types/pkg/package.json
+++ b/packages/plugin-bundle-types/pkg/package.json
@@ -15,9 +15,10 @@
     "url": "https://github.com/pikapkg/builders.git"
   },
   "dependencies": {
-    "@microsoft/api-extractor": "^7.1.5",
     "@pika/types": "^0.7.1",
-    "rimraf": "^2.6.3"
+    "rollup": "^1.1.0",
+    "rimraf": "^3.0.0",
+    "rollup-plugin-dts": "^1.1.12"
   },
   "devDependencies": {
     "@pika/pack": "^0.5.0",

--- a/packages/plugin-bundle-types/src/index.ts
+++ b/packages/plugin-bundle-types/src/index.ts
@@ -2,221 +2,9 @@ import path from 'path';
 import fs from 'fs';
 import rimraf from 'rimraf';
 import {BuilderOptions, MessageError} from '@pika/types';
-import {Extractor, ExtractorConfig, ExtractorResult, IConfigFile} from '@microsoft/api-extractor';
+import {rollup} from 'rollup';
+import rollupPluginDts from 'rollup-plugin-dts';
 const DEFAULT_ENTRYPOINT = 'types';
-
-/**
- * Config file for API Extractor.  For more info, please visit: https://api-extractor.com
- */
-function getConfigData(cwd: string, out: string, tsConfigPath: string) {
-  return {
-    $schema: 'https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json',
-
-    /**
-     * Optionally specifies another JSON config file that this file extends from.  This provides a way for
-     * standard settings to be shared across multiple projects.
-     *
-     * If the path starts with "./" or "../", the path is resolved relative to the folder of the file that contains
-     * the "extends" field.  Otherwise, the first path segment is interpreted as an NPM package name, and will be
-     * resolved using NodeJS require().
-     *
-     * SUPPORTED TOKENS: none
-     * DEFAULT VALUE: ""
-     */
-    // "extends": "./shared/api-extractor-base.json"
-    // "extends": "my-package/include/api-extractor-base.json"
-
-    /**
-     * Determines the "<projectFolder>" token that can be used with other config file settings.  The project folder
-     * typically contains the tsconfig.json and package.json config files, but the path is user-defined.
-     *
-     * The path is resolved relative to the folder of the config file that contains the setting.
-     *
-     * The default value for "projectFolder" is the token "<lookup>", which means the folder is determined by traversing
-     * parent folders, starting from the folder containing api-extractor.json, and stopping at the first folder
-     * that contains a tsconfig.json file.  If a tsconfig.json file cannot be found in this way, then an error
-     * will be reported.
-     *
-     * SUPPORTED TOKENS: <lookup>
-     * DEFAULT VALUE: "<lookup>"
-     */
-    projectFolder: cwd,
-
-    /**
-     * (REQUIRED) Specifies the .d.ts file to be used as the starting point for analysis.  API Extractor
-     * analyzes the symbols exported by this module.
-     *
-     * The file extension must be ".d.ts" and not ".ts".
-     *
-     * The path is resolved relative to the folder of the config file that contains the setting; to change this,
-     * prepend a folder token such as "<projectFolder>".
-     *
-     * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
-     */
-    mainEntryPointFilePath: `${out}/dist-types/index.d.ts`,
-
-    /**
-     * Determines how the TypeScript compiler engine will be invoked by API Extractor.
-     */
-    compiler: {
-      tsconfigFilePath: tsConfigPath,
-      /**
-       * Provides a compiler configuration that will be used instead of reading the tsconfig.json file from disk.
-       * The object must conform to the TypeScript tsconfig schema:
-       *
-       * http://json.schemastore.org/tsconfig
-       *
-       * If omitted, then the tsconfig.json file will be read from the "projectFolder".
-       *
-       * DEFAULT VALUE: no overrideTsconfig section
-       */
-      // "overrideTsconfig": {
-      //   . . .
-      // }
-      /**
-       * This option causes the compiler to be invoked with the --skipLibCheck option. This option is not recommended
-       * and may cause API Extractor to produce incomplete or incorrect declarations, but it may be required when
-       * dependencies contain declarations that are incompatible with the TypeScript engine that API Extractor uses
-       * for its analysis.  Where possible, the underlying issue should be fixed rather than relying on skipLibCheck.
-       *
-       * DEFAULT VALUE: false
-       */
-      // "skipLibCheck": true,
-    },
-
-    /**
-     * Configures how the API report file (*.api.md) will be generated.
-     */
-    apiReport: {enabled: false, reportFileName: 'report.api.md'},
-    docModel: {enabled: false},
-    tsdocMetadata: {enabled: false},
-    dtsRollup: {
-      enabled: true,
-      /**
-       * Specifies the output path for a .d.ts rollup file to be generated without any trimming.
-       * This file will include all declarations that are exported by the main entry point.
-       *
-       * If the path is an empty string, then this file will not be written.
-       *
-       * The path is resolved relative to the folder of the config file that contains the setting; to change this,
-       * prepend a folder token such as "<projectFolder>".
-       *
-       * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
-       * DEFAULT VALUE: "<projectFolder>/dist/<unscopedPackageName>.d.ts"
-       */
-      untrimmedFilePath: `${out}/dist-types-bundled/index.d.ts`,
-    },
-
-    /**
-     * Configures how API Extractor reports error and warning messages produced during analysis.
-     *
-     * There are three sources of messages:  compiler messages, API Extractor messages, and TSDoc messages.
-     */
-    messages: {
-      /**
-       * Configures handling of diagnostic messages reported by the TypeScript compiler engine while analyzing
-       * the input .d.ts files.
-       *
-       * TypeScript message identifiers start with "TS" followed by an integer.  For example: "TS2551"
-       *
-       * DEFAULT VALUE:  A single "default" entry with logLevel=warning.
-       */
-      compilerMessageReporting: {
-        /**
-         * Configures the default routing for messages that don't match an explicit rule in this table.
-         */
-        default: {
-          /**
-           * Specifies whether the message should be written to the the tool's output log.  Note that
-           * the "addToApiReportFile" property may supersede this option.
-           *
-           * Possible values: "error", "warning", "none"
-           *
-           * Errors cause the build to fail and return a nonzero exit code.  Warnings cause a production build fail
-           * and return a nonzero exit code.  For a non-production build (e.g. when "api-extractor run" includes
-           * the "--local" option), the warning is displayed but the build will not fail.
-           *
-           * DEFAULT VALUE: "warning"
-           */
-          logLevel: 'error',
-
-          /**
-           * When addToApiReportFile is true:  If API Extractor is configured to write an API report file (.api.md),
-           * then the message will be written inside that file; otherwise, the message is instead logged according to
-           * the "logLevel" option.
-           *
-           * DEFAULT VALUE: false
-           */
-          // "addToApiReportFile": false
-        },
-
-        // "TS2551": {
-        //   "logLevel": "warning",
-        //   "addToApiReportFile": true
-        // },
-        //
-        // . . .
-      },
-
-      /**
-       * Configures handling of messages reported by API Extractor during its analysis.
-       *
-       * API Extractor message identifiers start with "ae-".  For example: "ae-extra-release-tag"
-       *
-       * DEFAULT VALUE: See api-extractor-defaults.json for the complete table of extractorMessageReporting mappings
-       */
-      // extractorMessageReporting: {
-      //   default: {
-      //     logLevel: "error"
-      //   }
-      // },
-      //     // "addToApiReportFile": false
-      //   }
-
-      //   // "ae-extra-release-tag": {
-      //   //   "logLevel": "warning",
-      //   //   "addToApiReportFile": true
-      //   // },
-      //   //
-      //   // . . .
-      // },
-
-      /**
-       * Configures handling of messages reported by the TSDoc parser when analyzing code comments.
-       *
-       * TSDoc message identifiers start with "tsdoc-".  For example: "tsdoc-link-tag-unescaped-text"
-       *
-       * DEFAULT VALUE:  A single "default" entry with logLevel=warning.
-       */
-      // tsdocMessageReporting: {
-      //   default: {
-      //     logLevel: "warning"
-      //   }
-      // }
-      //     // "addToApiReportFile": false
-      //   }
-
-      //   // "tsdoc-link-tag-unescaped-text": {
-      //   //   "logLevel": "warning",
-      //   //   "addToApiReportFile": true
-      //   // },
-      //   //
-      //   // . . .
-      // }
-    },
-  } as IConfigFile;
-}
-
-function getTsConfigPath(options, cwd) {
-  return path.resolve(cwd, options.tsconfig || 'tsconfig.json');
-}
-
-export async function beforeBuild({cwd, options}: BuilderOptions) {
-  const tsConfigPath = getTsConfigPath(options, cwd);
-  if (!fs.existsSync(tsConfigPath)) {
-    throw new MessageError('"tsconfig.json" manifest not found.');
-  }
-}
 
 export async function beforeJob({out}: BuilderOptions) {
   const typesDir = path.join(out, 'dist-types');
@@ -237,36 +25,23 @@ export function manifest(manifest, {options}: BuilderOptions) {
       keys = [keys];
     }
     for (const key of keys) {
-      manifest[key] = manifest[key] || 'dist-types/index.d.ts';
+      manifest[key] = 'dist-types/index.d.ts';
     }
   }
 }
 
-export async function build({cwd, out, options, reporter, manifest}: BuilderOptions): Promise<void> {
-  const typesBundledLoc = path.join(out, 'dist-types-bundled/');
-  const typesLoc = path.join(out, 'dist-types/');
-
-  // Load and parse the api-extractor.json file
-  const extractorConfig: ExtractorConfig = ExtractorConfig.prepare({
-    configObject: getConfigData(cwd, out, getTsConfigPath(options, cwd)),
-    configObjectFullPath: undefined,
-    packageJson: manifest,
-    packageJsonFullPath: path.join(cwd, 'package.json'),
+export async function build({out, options, reporter}: BuilderOptions): Promise<void> {
+  const readFromTypes = path.join(out, 'dist-types', 'index.d.ts');
+  const writeToTypes = path.join(out, 'dist-types');
+  const writeToTypesBundled = path.join(writeToTypes, 'index.d.ts');
+  const result = await rollup({
+    input: readFromTypes,
+    plugins: [rollupPluginDts()],
   });
-  (extractorConfig as any).packageJson = manifest;
-
-  // Invoke API Extractor to generate a bundled index.d.ts from the dist-types-unbundled/ dir.
-  const extractorResult: ExtractorResult = Extractor.invoke(extractorConfig, {localBuild: false});
-
-  // Handle a failure
-  if (!extractorResult.succeeded) {
-    throw new MessageError(
-      `Unable to bundle types. ${extractorResult.errorCount} errors` +
-        ` and ${extractorResult.warningCount} warnings encountered.`,
-    );
-  }
-
-  rimraf.sync(typesLoc);
-  fs.renameSync(typesBundledLoc, typesLoc);
-  reporter.created(path.join(out, 'dist-types', 'index.d.ts'), 'types, bundled');
+  rimraf.sync(writeToTypes);
+  await result.write({
+    file: writeToTypesBundled,
+    format: 'esm',
+  });
+  reporter.created(writeToTypesBundled);
 }

--- a/packages/plugin-bundle-web/package-lock.json
+++ b/packages/plugin-bundle-web/package-lock.json
@@ -1456,9 +1456,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.3.312",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.312.tgz",
-			"integrity": "sha512-/Nk6Hvwt+RfS9X3oA4IXpWqpcnS7cdWsTMP4AmrP8hPpxtZbHemvTEYzjAKghk28aS9zIV8NwGHNt8H+6OmJug=="
+			"version": "1.3.313",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.313.tgz",
+			"integrity": "sha512-rWbB6P3kPpWez/BZqrVatQ+lxJaDTv9pWgUUGYAA0/O5+YZLm6RiGy2Roml6rQj4EJ4r/eTdO0ppOZUUP2oFpQ=="
 		},
 		"elegant-spinner": {
 			"version": "1.0.1",


### PR DESCRIPTION
api-extractor was a ton of tooling/configuration overhead for the small bundling task that we needed. More importantly, this fixes the errors that we saw where api-extractor would fail because of missing references.