### PR TITLE
Fix typo in error message

### DIFF
--- a/packages/plugin-bundle-web/src/index.ts
+++ b/packages/plugin-bundle-web/src/index.ts
@@ -18,7 +18,7 @@ export async function beforeJob({out}: BuilderOptions) {
   const srcDirectory = path.join(out, 'dist-web/');
   if (!fs.existsSync(srcDirectory)) {
     throw new MessageError(
-      '"dist-web/" does not exist. "plugin-bundle-web" requires "plugin-build-dev" to precede in pipeline.',
+      '"dist-web/" does not exist. "plugin-bundle-web" requires "plugin-build-web" to precede in pipeline.',
     );
   }
   const srcEntrypoint = path.join(out, 'dist-web/index.js');


### PR DESCRIPTION
Just changing `plugin-build-dev` to `plugin-build-web` in an error message.