### PR TITLE
[umd] add exports option

### DIFF
--- a/packages/plugin-build-umd/README.md
+++ b/packages/plugin-build-umd/README.md
@@ -37,6 +37,7 @@ For more information about @pika/pack & help getting started, [check out the mai
 - `"sourcemap"` (Default: `"true"`): Adds a [source map](https://www.html5rocks.com/en/tutorials/developertools/sourcemaps/) for this build.
 - `"name"` (Defaults: your package name): Sets the name that your package is attached to on the `window` object.
 - `"entrypoint"` (Default: `"umd:main"`): Customize the package.json manifest entrypoint set by this plugin. Accepts either a string, an array of strings, or `null` to disable entrypoint. Changing this is not recommended for most usage.
+- `"exports"` (Default: `"named"`): Customize rollup [`output.exports`](option https://rollupjs.org/guide/en/#outputexports).
 
 
 ## Result

--- a/packages/plugin-build-umd/src/index.ts
+++ b/packages/plugin-build-umd/src/index.ts
@@ -72,7 +72,7 @@ export async function build({out, reporter, options}: BuilderOptions): Promise<v
   await result.write({
     file: writeToUmd,
     format: 'umd',
-    exports: 'named',
+    exports: options.exports === undefined ? 'named' : options.exports,
     name: umdExportName,
     sourcemap: options.sourcemap === undefined ? true : options.sourcemap,
   });


### PR DESCRIPTION
Add support for customizing rollup's `output.exports` option https://rollupjs.org/guide/en/#outputexports